### PR TITLE
feat: add pnpm_global_packages and bun_global_packages support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,9 +84,10 @@ Package lists are flat YAML arrays grouped by category:
   Chocolatey (`pnpm`, `bun`) on Windows,
   and via `npm_global_packages` (`pnpm`, `bun`) on Linux.
   pnpm needs its global bin directory on `PATH`, so the steps export
-  `PNPM_HOME=~/Library/pnpm` and prepend `$PNPM_HOME/bin` (pnpm's default
-  global bin dir) -- matching the shell configs' pnpm convention, so no pnpm
-  config file is written.
+  `PNPM_HOME` (`~/Library/pnpm` on macOS to match the shell configs,
+  `~/.local/share/pnpm` on Linux, `%LOCALAPPDATA%\pnpm` on Windows) and
+  prepend `$PNPM_HOME/bin` (pnpm's default global bin dir), so no pnpm config
+  file is written.
 
 ## Running the Setup Scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ Package lists are flat YAML arrays grouped by category:
   `apt_packages` / `snap_packages` / `dnf_packages` / `flatpak_packages` /
   `appimage_packages`
 - **Cross-platform**: `powershell_modules`, `pipx_packages`, `uv_tools`,
-  `npm_global_packages`, `dotnet_tools`, `vscode_extensions`
+  `npm_global_packages`, `pnpm_global_packages`, `bun_global_packages`,
+  `dotnet_tools`, `vscode_extensions`
 - **Git config**: `git_user_email`, `git_user_name`
 - **Custom commands**: `custom_commands_user` (non-elevated), `custom_commands_elevated` (sudo)
 - **Custom script**: `custom_script` (path to a script run at the end)
@@ -74,6 +75,17 @@ Package lists are flat YAML arrays grouped by category:
   then uv manages the rest).
   The uv tools step is guarded on uv being installed --
   if uv is not on PATH, the step is silently skipped.
+- **`pnpm_global_packages`** / **`bun_global_packages`** install global CLI tools
+  via `pnpm add -g` / `bun add -g`.
+  Like `uv_tools`, both steps are guarded on the tool being installed --
+  if `pnpm` / `bun` is not on PATH, the step is silently skipped.
+  The binaries are installed as ordinary package-manager entries:
+  Homebrew (`pnpm` formula, `oven-sh/bun` tap + `oven-sh/bun/bun` formula) on macOS,
+  Chocolatey (`pnpm`, `bun`) on Windows,
+  and via `npm_global_packages` (`pnpm`, `bun`) on Linux.
+  pnpm requires a global bin directory, so the steps set `PNPM_HOME`
+  (`~/Library/pnpm` on macOS, `~/.local/share/pnpm` on Linux,
+  `%LOCALAPPDATA%\pnpm` on Windows) and add it to `PATH`.
 
 ## Running the Setup Scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Package lists are flat YAML arrays grouped by category:
   Like `uv_tools`, both steps are guarded on the tool being installed --
   if `pnpm` / `bun` is not on PATH, the step is silently skipped.
   The binaries are installed as ordinary package-manager entries:
-  Homebrew (`pnpm` formula, `oven-sh/bun` tap + `oven-sh/bun/bun` formula) on macOS,
+  Homebrew (`pnpm`, `bun` formulae) on macOS,
   Chocolatey (`pnpm`, `bun`) on Windows,
   and via `npm_global_packages` (`pnpm`, `bun`) on Linux.
   pnpm requires a global bin directory, so the steps set `PNPM_HOME`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,10 @@ Package lists are flat YAML arrays grouped by category:
   Homebrew (`pnpm`, `bun` formulae) on macOS,
   Chocolatey (`pnpm`, `bun`) on Windows,
   and via `npm_global_packages` (`pnpm`, `bun`) on Linux.
-  pnpm requires a global bin directory, so the steps set `PNPM_HOME`
-  (`~/Library/pnpm` on macOS, `~/.local/share/pnpm` on Linux,
-  `%LOCALAPPDATA%\pnpm` on Windows) and add it to `PATH`.
+  pnpm needs its global bin directory on `PATH`, so the steps export
+  `PNPM_HOME=~/Library/pnpm` and prepend `$PNPM_HOME/bin` (pnpm's default
+  global bin dir) -- matching the shell configs' pnpm convention, so no pnpm
+  config file is written.
 
 ## Running the Setup Scripts
 

--- a/debian/README.md
+++ b/debian/README.md
@@ -9,7 +9,7 @@ development environment.
 - **APT Package Management**: Installs essential development tools and applications
 - **Flatpak Package Management**: Installs GUI applications via Flatpak
 - **Python Setup**: Bootstraps uv via pipx and installs Python CLI tools via uv
-- **Node.js Setup**: Installs npm global packages
+- **Node.js Setup**: Installs npm/pnpm/bun global packages
 - **VS Code Extensions**: Configures VS Code with essential development extensions
 - **Git Setup**: Configures Git with user information, Git LFS, and Git Credential Manager
 - **AppImage Support**: Installs applications via AppImage with desktop integration

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -230,6 +230,97 @@
         - npm
         - packages
 
+    # pnpm presence check
+    - name: Check if pnpm is installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which pnpm
+      register: pnpm_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - pnpm
+        - packages
+
+    # pnpm global package checks
+    - name: Check if pnpm packages are already installed
+      ansible.builtin.shell: |
+        export PNPM_HOME=~/.local/share/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        pnpm list -g {{ item }}
+      register: pnpm_check_result
+      changed_when: false
+      failed_when: false
+      when: pnpm_check.rc == 0
+      loop: "{{ pnpm_global_packages | default([], true) }}"
+      loop_control:
+        label: "Checking pnpm package: {{ item }}"
+      tags:
+        - pnpm
+        - packages
+
+    # pnpm global package installs
+    - name: Ensure pnpm global packages are installed
+      ansible.builtin.shell: |
+        export PNPM_HOME=~/.local/share/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        mkdir -p "$PNPM_HOME"
+        pnpm add -g {{ item.0 }}
+      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+      when:
+        - pnpm_check.rc == 0
+        - item.1.rc is defined
+        - item.1.rc != 0
+      register: pnpm_install_result
+      changed_when: "pnpm_install_result.rc == 0"
+      loop_control:
+        label: "Installing pnpm package: {{ item.0 }}"
+      tags:
+        - pnpm
+        - packages
+
+    # bun presence check
+    - name: Check if bun is installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which bun
+      register: bun_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - bun
+        - packages
+
+    # bun global package list
+    - name: Check if bun packages are already installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:~/.bun/bin:$PATH
+        bun pm ls -g
+      register: bun_list_result
+      changed_when: false
+      failed_when: false
+      when: bun_check.rc == 0
+      tags:
+        - bun
+        - packages
+
+    # bun global package installs
+    - name: Ensure bun global packages are installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:~/.bun/bin:$PATH
+        bun add -g {{ item }}
+      loop: "{{ bun_global_packages | default([], true) }}"
+      when:
+        - bun_check.rc == 0
+        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+      register: bun_install_result
+      changed_when: "bun_install_result.rc == 0"
+      loop_control:
+        label: "Installing bun package: {{ item }}"
+      tags:
+        - bun
+        - packages
+
     # .NET Install check
     - name: Check if dotnet is installed
       ansible.builtin.command:

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -242,19 +242,18 @@
         - pnpm
         - packages
 
-    # pnpm global package checks
-    - name: Check if pnpm packages are already installed
+    # pnpm global package list
+    # pnpm list -g always exits 0, so detect installed packages from the JSON
+    # output (keyed by bare name) rather than the exit code.
+    - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
-        pnpm list -g {{ item }}
-      register: pnpm_check_result
+        pnpm list -g --depth=0 --json
+      register: pnpm_list_result
       changed_when: false
       failed_when: false
       when: pnpm_check.rc == 0
-      loop: "{{ pnpm_global_packages | default([], true) }}"
-      loop_control:
-        label: "Checking pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages
@@ -265,16 +264,15 @@
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
         mkdir -p "$PNPM_HOME"
-        pnpm add -g {{ item.0 }}
-      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+        pnpm add -g {{ item }}
+      loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item.1.rc is defined
-        - item.1.rc != 0
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
-        label: "Installing pnpm package: {{ item.0 }}"
+        label: "Installing pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -247,7 +247,7 @@
     # output (keyed by bare name) rather than the exit code.
     - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/Library/pnpm
+        export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         pnpm list -g --depth=0 --json
       register: pnpm_list_result
@@ -265,7 +265,7 @@
     # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/Library/pnpm
+        export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -312,7 +312,7 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+        - item not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       loop_control:

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -247,8 +247,8 @@
     # output (keyed by bare name) rather than the exit code.
     - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/.local/share/pnpm
-        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        export PNPM_HOME=~/Library/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         pnpm list -g --depth=0 --json
       register: pnpm_list_result
       changed_when: false
@@ -259,12 +259,15 @@
         - packages
 
     # pnpm global package installs
+    # pnpm installs global binaries into its global bin dir ($PNPM_HOME/bin,
+    # pnpm's default), which must exist and be on PATH or it errors with
+    # ERR_PNPM_NO_GLOBAL_BIN_DIR. This mirrors the PNPM_HOME + $PNPM_HOME/bin
+    # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/.local/share/pnpm
-        export PATH=~/.local/bin:$PNPM_HOME:$PATH
-        mkdir -p "$PNPM_HOME"
-        pnpm config set global-bin-dir "$PNPM_HOME"
+        export PNPM_HOME=~/Library/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
+        mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -264,6 +264,7 @@
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
         mkdir -p "$PNPM_HOME"
+        pnpm config set global-bin-dir "$PNPM_HOME"
         pnpm add -g {{ item }}
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:

--- a/debian/vars.yaml
+++ b/debian/vars.yaml
@@ -195,13 +195,23 @@ uv_tools:
   - taskcat
 
 # npm global packages
+# pnpm and bun are installed here via npm so they are available for the
+# pnpm_global_packages / bun_global_packages steps and easy to update.
 npm_global_packages:
   - '@github/copilot'
   - '@vue/cli'
   - aws-cdk
   - azure-functions-core-tools@4
+  - bun
   - npmrc
+  - pnpm
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/examples/debian_vars.yaml
+++ b/examples/debian_vars.yaml
@@ -244,8 +244,16 @@ npm_global_packages:
   - '@vue/cli'
   - aws-cdk
   - azure-functions-core-tools@4
+  - bun
   - npmrc
+  - pnpm
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/examples/fedora_vars.yaml
+++ b/examples/fedora_vars.yaml
@@ -229,8 +229,16 @@ npm_global_packages:
   - '@vue/cli'
   - aws-cdk
   - azure-functions-core-tools@4
+  - bun
   - npmrc
+  - pnpm
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -11,7 +11,6 @@ homebrew_taps:
   - azure/functions
   - hashicorp/tap
   - microsoft/git
-  - oven-sh/bun
   - teamookla/speedtest
 
 homebrew_casks:
@@ -77,6 +76,7 @@ homebrew_formulae:
   - bat
   - beads
   - bicep
+  - bun
   - cfn-lint
   - chruby
   - chruby-fish
@@ -115,7 +115,6 @@ homebrew_formulae:
   - node
   - nvm
   - oh-my-posh
-  - oven-sh/bun/bun
   - pandoc
   - pinentry-mac
   - pipx

--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -174,6 +174,12 @@ uv_tools:
   - taskcat
 
 npm_global_packages:
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
   - '@vue/cli'
   - aws-cdk
   - npmrc

--- a/examples/ubuntu_vars.yaml
+++ b/examples/ubuntu_vars.yaml
@@ -355,8 +355,16 @@ npm_global_packages:
   - '@vue/cli'
   - aws-cdk
   - azure-functions-core-tools@4
+  - bun
   - npmrc
+  - pnpm
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/examples/windows_vars.yaml
+++ b/examples/windows_vars.yaml
@@ -13,6 +13,7 @@ choco_packages:
   - name: azure-cli
   - name: azure-functions-core-tools
   - name: bicep
+  - name: bun
   - name: cascadiacode
   - name: citrix-workspace
   - name: cursoride
@@ -48,6 +49,7 @@ choco_packages:
   - name: office365business
   - name: oh-my-posh
   - name: packer
+  - name: pnpm
   # Required to for pipx_packages
   - name: python
   - name: pwsh
@@ -131,6 +133,12 @@ npm_global_packages:
   - aws-cdk
   - npmrc
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -12,7 +12,7 @@ development environment.
 - **PowerShell Setup**: Installs PowerShell and modules for development
 - **Python Setup**: Installs Python versions via pyenv, bootstraps uv via pipx, and installs CLI tools via uv
 - **Ruby Setup**: Installs Ruby via chruby
-- **Node.js Setup**: Installs Node.js and npm global packages
+- **Node.js Setup**: Installs Node.js and npm/pnpm/bun global packages
 - **Rust Setup**: Installs Rust via rustup
 - **Go Setup**: Installs Go
 - **.NET Setup**: Installs .NET SDK and global tools

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -237,8 +237,8 @@
     # output (keyed by bare name) rather than the exit code.
     - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/.local/share/pnpm
-        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        export PNPM_HOME=~/Library/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         pnpm list -g --depth=0 --json
       register: pnpm_list_result
       changed_when: false
@@ -249,12 +249,15 @@
         - packages
 
     # pnpm global package installs
+    # pnpm installs global binaries into its global bin dir ($PNPM_HOME/bin,
+    # pnpm's default), which must exist and be on PATH or it errors with
+    # ERR_PNPM_NO_GLOBAL_BIN_DIR. This mirrors the PNPM_HOME + $PNPM_HOME/bin
+    # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/.local/share/pnpm
-        export PATH=~/.local/bin:$PNPM_HOME:$PATH
-        mkdir -p "$PNPM_HOME"
-        pnpm config set global-bin-dir "$PNPM_HOME"
+        export PNPM_HOME=~/Library/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
+        mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -254,6 +254,7 @@
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
         mkdir -p "$PNPM_HOME"
+        pnpm config set global-bin-dir "$PNPM_HOME"
         pnpm add -g {{ item }}
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -232,19 +232,18 @@
         - pnpm
         - packages
 
-    # pnpm global package checks
-    - name: Check if pnpm packages are already installed
+    # pnpm global package list
+    # pnpm list -g always exits 0, so detect installed packages from the JSON
+    # output (keyed by bare name) rather than the exit code.
+    - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
-        pnpm list -g {{ item }}
-      register: pnpm_check_result
+        pnpm list -g --depth=0 --json
+      register: pnpm_list_result
       changed_when: false
       failed_when: false
       when: pnpm_check.rc == 0
-      loop: "{{ pnpm_global_packages | default([], true) }}"
-      loop_control:
-        label: "Checking pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages
@@ -255,16 +254,15 @@
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
         mkdir -p "$PNPM_HOME"
-        pnpm add -g {{ item.0 }}
-      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+        pnpm add -g {{ item }}
+      loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item.1.rc is defined
-        - item.1.rc != 0
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
-        label: "Installing pnpm package: {{ item.0 }}"
+        label: "Installing pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -237,7 +237,7 @@
     # output (keyed by bare name) rather than the exit code.
     - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/Library/pnpm
+        export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         pnpm list -g --depth=0 --json
       register: pnpm_list_result
@@ -255,7 +255,7 @@
     # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/Library/pnpm
+        export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -302,7 +302,7 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+        - item not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       loop_control:

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -220,6 +220,97 @@
         - npm
         - packages
 
+    # pnpm presence check
+    - name: Check if pnpm is installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which pnpm
+      register: pnpm_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - pnpm
+        - packages
+
+    # pnpm global package checks
+    - name: Check if pnpm packages are already installed
+      ansible.builtin.shell: |
+        export PNPM_HOME=~/.local/share/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        pnpm list -g {{ item }}
+      register: pnpm_check_result
+      changed_when: false
+      failed_when: false
+      when: pnpm_check.rc == 0
+      loop: "{{ pnpm_global_packages | default([], true) }}"
+      loop_control:
+        label: "Checking pnpm package: {{ item }}"
+      tags:
+        - pnpm
+        - packages
+
+    # pnpm global package installs
+    - name: Ensure pnpm global packages are installed
+      ansible.builtin.shell: |
+        export PNPM_HOME=~/.local/share/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        mkdir -p "$PNPM_HOME"
+        pnpm add -g {{ item.0 }}
+      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+      when:
+        - pnpm_check.rc == 0
+        - item.1.rc is defined
+        - item.1.rc != 0
+      register: pnpm_install_result
+      changed_when: "pnpm_install_result.rc == 0"
+      loop_control:
+        label: "Installing pnpm package: {{ item.0 }}"
+      tags:
+        - pnpm
+        - packages
+
+    # bun presence check
+    - name: Check if bun is installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which bun
+      register: bun_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - bun
+        - packages
+
+    # bun global package list
+    - name: Check if bun packages are already installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:~/.bun/bin:$PATH
+        bun pm ls -g
+      register: bun_list_result
+      changed_when: false
+      failed_when: false
+      when: bun_check.rc == 0
+      tags:
+        - bun
+        - packages
+
+    # bun global package installs
+    - name: Ensure bun global packages are installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:~/.bun/bin:$PATH
+        bun add -g {{ item }}
+      loop: "{{ bun_global_packages | default([], true) }}"
+      when:
+        - bun_check.rc == 0
+        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+      register: bun_install_result
+      changed_when: "bun_install_result.rc == 0"
+      loop_control:
+        label: "Installing bun package: {{ item }}"
+      tags:
+        - bun
+        - packages
+
     # .NET Install check
     - name: Check if dotnet is installed
       ansible.builtin.command:

--- a/fedora/vars.yaml
+++ b/fedora/vars.yaml
@@ -126,13 +126,23 @@ uv_tools:
   - taskcat
 
 # npm global packages
+# pnpm and bun are installed here via npm so they are available for the
+# pnpm_global_packages / bun_global_packages steps and easy to update.
 npm_global_packages:
   - '@github/copilot'
   - '@vue/cli'
   - aws-cdk
   - azure-functions-core-tools@4
+  - bun
   - npmrc
+  - pnpm
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/macOS/README.md
+++ b/macOS/README.md
@@ -145,6 +145,14 @@ npm_global_packages:
   - aws-cdk
   - npmrc
 
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+  - aws-cdk
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
+  - aws-cdk
+
 # .NET global tools (requires .NET SDK)
 dotnet_tools:
   - Amazon.Lambda.Tools

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -218,20 +218,20 @@
       when: pnpm_check.rc == 0
       environment:
         PNPM_HOME: "{{ ansible_env.HOME }}/Library/pnpm"
-        PATH: "{{ ansible_env.HOME }}/Library/pnpm:{{ ansible_env.PATH }}"
+        PATH: "{{ ansible_env.HOME }}/Library/pnpm/bin:{{ ansible_env.PATH }}"
       tags:
         - pnpm
         - packages
 
-    # pnpm add -g needs its global bin dir configured and on PATH, otherwise it
-    # errors with ERR_PNPM_NO_GLOBAL_BIN_DIR. Pin global-bin-dir to PNPM_HOME so
-    # installed binaries land directly in ~/Library/pnpm.
+    # pnpm installs global binaries into its global bin dir ($PNPM_HOME/bin,
+    # pnpm's default), which must exist and be on PATH or it errors with
+    # ERR_PNPM_NO_GLOBAL_BIN_DIR. This mirrors the PNPM_HOME + $PNPM_HOME/bin
+    # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
         export PNPM_HOME="$HOME/Library/pnpm"
-        export PATH="$PNPM_HOME:$PATH"
-        mkdir -p "$PNPM_HOME"
-        pnpm config set global-bin-dir "$PNPM_HOME"
+        export PATH="$PNPM_HOME/bin:$PATH"
+        mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}
       failed_when: false
       loop: "{{ pnpm_global_packages | default([], true) }}"

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -275,7 +275,7 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+        - item not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       environment:

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -196,6 +196,96 @@
         - npm
         - packages
 
+    # pnpm global package setup
+    - name: Check if pnpm is installed
+      ansible.builtin.command:
+        cmd: which pnpm
+      register: pnpm_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - pnpm
+        - packages
+
+    - name: Check if pnpm packages are already installed
+      ansible.builtin.command:
+        cmd: pnpm list -g {{ item }}
+      register: pnpm_check_result
+      changed_when: false
+      failed_when: false
+      when: pnpm_check.rc == 0
+      loop: "{{ pnpm_global_packages | default([], true) }}"
+      environment:
+        PNPM_HOME: "{{ ansible_env.HOME }}/Library/pnpm"
+        PATH: "{{ ansible_env.HOME }}/Library/pnpm:{{ ansible_env.PATH }}"
+      loop_control:
+        label: "Checking pnpm package: {{ item }}"
+      tags:
+        - pnpm
+        - packages
+
+    - name: Ensure pnpm global packages are installed
+      ansible.builtin.command:
+        cmd: pnpm add -g {{ item.0 }}
+      failed_when: false
+      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+      when:
+        - pnpm_check.rc == 0
+        - item.1.rc is defined
+        - item.1.rc != 0
+      register: pnpm_install_result
+      changed_when: "pnpm_install_result.rc == 0"
+      environment:
+        PNPM_HOME: "{{ ansible_env.HOME }}/Library/pnpm"
+        PATH: "{{ ansible_env.HOME }}/Library/pnpm:{{ ansible_env.PATH }}"
+      loop_control:
+        label: "Installing pnpm package: {{ item.0 }}"
+      tags:
+        - pnpm
+        - packages
+
+    # bun global package setup
+    - name: Check if bun is installed
+      ansible.builtin.command:
+        cmd: which bun
+      register: bun_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - bun
+        - packages
+
+    - name: Check if bun packages are already installed
+      ansible.builtin.command:
+        cmd: bun pm ls -g
+      register: bun_list_result
+      changed_when: false
+      failed_when: false
+      when: bun_check.rc == 0
+      environment:
+        PATH: "{{ ansible_env.HOME }}/.bun/bin:{{ ansible_env.PATH }}"
+      tags:
+        - bun
+        - packages
+
+    - name: Ensure bun global packages are installed
+      ansible.builtin.command:
+        cmd: bun add -g {{ item }}
+      failed_when: false
+      loop: "{{ bun_global_packages | default([], true) }}"
+      when:
+        - bun_check.rc == 0
+        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+      register: bun_install_result
+      changed_when: "bun_install_result.rc == 0"
+      environment:
+        PATH: "{{ ansible_env.HOME }}/.bun/bin:{{ ansible_env.PATH }}"
+      loop_control:
+        label: "Installing bun package: {{ item }}"
+      tags:
+        - bun
+        - packages
+
     # .NET Global Tools setup
     - name: Check if dotnet is installed
       ansible.builtin.command:

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -207,39 +207,37 @@
         - pnpm
         - packages
 
-    - name: Check if pnpm packages are already installed
+    # pnpm list -g always exits 0, so detect installed packages from the JSON
+    # output (keyed by bare name) rather than the exit code.
+    - name: Check which pnpm global packages are already installed
       ansible.builtin.command:
-        cmd: pnpm list -g {{ item }}
-      register: pnpm_check_result
+        cmd: pnpm list -g --depth=0 --json
+      register: pnpm_list_result
       changed_when: false
       failed_when: false
       when: pnpm_check.rc == 0
-      loop: "{{ pnpm_global_packages | default([], true) }}"
       environment:
         PNPM_HOME: "{{ ansible_env.HOME }}/Library/pnpm"
         PATH: "{{ ansible_env.HOME }}/Library/pnpm:{{ ansible_env.PATH }}"
-      loop_control:
-        label: "Checking pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages
 
     - name: Ensure pnpm global packages are installed
       ansible.builtin.command:
-        cmd: pnpm add -g {{ item.0 }}
+        cmd: pnpm add -g {{ item }}
       failed_when: false
-      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+      loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item.1.rc is defined
-        - item.1.rc != 0
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       environment:
         PNPM_HOME: "{{ ansible_env.HOME }}/Library/pnpm"
         PATH: "{{ ansible_env.HOME }}/Library/pnpm:{{ ansible_env.PATH }}"
       loop_control:
-        label: "Installing pnpm package: {{ item.0 }}"
+        label: "Installing pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -223,9 +223,16 @@
         - pnpm
         - packages
 
+    # pnpm add -g needs its global bin dir configured and on PATH, otherwise it
+    # errors with ERR_PNPM_NO_GLOBAL_BIN_DIR. Pin global-bin-dir to PNPM_HOME so
+    # installed binaries land directly in ~/Library/pnpm.
     - name: Ensure pnpm global packages are installed
-      ansible.builtin.command:
-        cmd: pnpm add -g {{ item }}
+      ansible.builtin.shell: |
+        export PNPM_HOME="$HOME/Library/pnpm"
+        export PATH="$PNPM_HOME:$PATH"
+        mkdir -p "$PNPM_HOME"
+        pnpm config set global-bin-dir "$PNPM_HOME"
+        pnpm add -g {{ item }}
       failed_when: false
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
@@ -233,9 +240,6 @@
         - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
-      environment:
-        PNPM_HOME: "{{ ansible_env.HOME }}/Library/pnpm"
-        PATH: "{{ ansible_env.HOME }}/Library/pnpm:{{ ansible_env.PATH }}"
       loop_control:
         label: "Installing pnpm package: {{ item }}"
       tags:

--- a/macOS/vars.yaml
+++ b/macOS/vars.yaml
@@ -11,6 +11,7 @@ homebrew_taps:
   - azure/functions
   - hashicorp/tap
   - microsoft/git
+  - oven-sh/bun
 
 homebrew_casks:
   - citrix-workspace
@@ -65,7 +66,9 @@ homebrew_formulae:
   - node
   - nvm
   - oh-my-posh
+  - oven-sh/bun/bun
   - pipx
+  - pnpm
   - powershell
   - pyenv-virtualenv
   - python
@@ -111,6 +114,12 @@ npm_global_packages:
   - aws-cdk
   - npmrc
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/macOS/vars.yaml
+++ b/macOS/vars.yaml
@@ -11,7 +11,6 @@ homebrew_taps:
   - azure/functions
   - hashicorp/tap
   - microsoft/git
-  - oven-sh/bun
 
 homebrew_casks:
   - citrix-workspace
@@ -44,6 +43,7 @@ homebrew_formulae:
   - bash
   - bash-git-prompt
   - bicep
+  - bun
   - cfn-lint
   - chruby
   - chruby-fish
@@ -66,7 +66,6 @@ homebrew_formulae:
   - node
   - nvm
   - oh-my-posh
-  - oven-sh/bun/bun
   - pipx
   - pnpm
   - powershell

--- a/tests/debian/vars.yaml
+++ b/tests/debian/vars.yaml
@@ -10,6 +10,8 @@ apt_packages:
   - name: git
   - name: git-lfs
   - name: jq
+  - name: nodejs
+  - name: npm
 
 flatpak_packages: []
 
@@ -19,7 +21,13 @@ pipx_packages:
 
 uv_tools:
 
-npm_global_packages: []
+npm_global_packages:
+  - bun
+  - pnpm
+
+pnpm_global_packages:
+
+bun_global_packages:
 
 dotnet_tools: []
 

--- a/tests/debian/verify.sh
+++ b/tests/debian/verify.sh
@@ -37,6 +37,10 @@ check "git installed (APT package)" command -v git
 check "git-lfs installed (APT package)" command -v git-lfs
 check "jq installed (APT package)" command -v jq
 
+# pnpm + bun (installed via npm into ~/.local/bin)
+check "bun installed (npm global)" test -x "$HOME/.local/bin/bun"
+check "pnpm installed (npm global)" test -x "$HOME/.local/bin/pnpm"
+
 # Git config
 check_equal "git user.email configured" \
   "$(git config --global user.email)" "ci-test@example.com"

--- a/tests/fedora/vars.yaml
+++ b/tests/fedora/vars.yaml
@@ -10,6 +10,8 @@ dnf_packages:
   - name: git
   - name: git-lfs
   - name: jq
+  - name: nodejs
+  - name: npm
 
 flatpak_packages: []
 
@@ -19,7 +21,13 @@ pipx_packages:
 
 uv_tools:
 
-npm_global_packages: []
+npm_global_packages:
+  - bun
+  - pnpm
+
+pnpm_global_packages:
+
+bun_global_packages:
 
 dotnet_tools: []
 

--- a/tests/fedora/verify.sh
+++ b/tests/fedora/verify.sh
@@ -37,6 +37,10 @@ check "git installed (DNF package)" command -v git
 check "git-lfs installed (DNF package)" command -v git-lfs
 check "jq installed (DNF package)" command -v jq
 
+# pnpm + bun (installed via npm into ~/.local/bin)
+check "bun installed (npm global)" test -x "$HOME/.local/bin/bun"
+check "pnpm installed (npm global)" test -x "$HOME/.local/bin/pnpm"
+
 # Git config
 check_equal "git user.email configured" \
   "$(git config --global user.email)" "ci-test@example.com"

--- a/tests/macOS/vars.yaml
+++ b/tests/macOS/vars.yaml
@@ -22,7 +22,7 @@ uv_tools:
 npm_global_packages: []
 
 pnpm_global_packages:
-  - cowsay
+  - json
 
 bun_global_packages:
   - cowsay

--- a/tests/macOS/vars.yaml
+++ b/tests/macOS/vars.yaml
@@ -1,6 +1,7 @@
 install_rosetta: false
 
-homebrew_taps: []
+homebrew_taps:
+  - oven-sh/bun
 
 homebrew_casks:
   - iterm2
@@ -8,6 +9,8 @@ homebrew_casks:
 homebrew_formulae:
   - git-lfs
   - jq
+  - oven-sh/bun/bun
+  - pnpm
   - uv
 
 powershell_modules: []
@@ -18,6 +21,12 @@ uv_tools:
   - ruff
 
 npm_global_packages: []
+
+pnpm_global_packages:
+  - cowsay
+
+bun_global_packages:
+  - cowsay
 
 dotnet_tools: []
 

--- a/tests/macOS/vars.yaml
+++ b/tests/macOS/vars.yaml
@@ -1,15 +1,14 @@
 install_rosetta: false
 
-homebrew_taps:
-  - oven-sh/bun
+homebrew_taps: []
 
 homebrew_casks:
   - iterm2
 
 homebrew_formulae:
+  - bun
   - git-lfs
   - jq
-  - oven-sh/bun/bun
   - pnpm
   - uv
 

--- a/tests/macOS/verify.sh
+++ b/tests/macOS/verify.sh
@@ -43,7 +43,7 @@ check "pnpm installed (Homebrew formula)" command -v pnpm
 check "bun installed (Homebrew formula)" command -v bun
 
 # pnpm + bun global packages (distinct packages so each tool is verified independently)
-check "json installed (pnpm global)" test -e "$HOME/Library/pnpm/json"
+check "json installed (pnpm global)" test -e "$HOME/Library/pnpm/bin/json"
 check "cowsay installed (bun global)" test -e "$HOME/.bun/bin/cowsay"
 
 # Git config

--- a/tests/macOS/verify.sh
+++ b/tests/macOS/verify.sh
@@ -42,8 +42,8 @@ check "ruff installed (uv tool)" command -v ruff
 check "pnpm installed (Homebrew formula)" command -v pnpm
 check "bun installed (Homebrew formula)" command -v bun
 
-# pnpm + bun global packages
-check "cowsay installed (pnpm global)" test -e "$HOME/Library/pnpm/cowsay"
+# pnpm + bun global packages (distinct packages so each tool is verified independently)
+check "json installed (pnpm global)" test -e "$HOME/Library/pnpm/json"
 check "cowsay installed (bun global)" test -e "$HOME/.bun/bin/cowsay"
 
 # Git config

--- a/tests/macOS/verify.sh
+++ b/tests/macOS/verify.sh
@@ -38,6 +38,14 @@ check "iTerm2 installed (Homebrew cask)" test -d /Applications/iTerm.app
 # uv tool
 check "ruff installed (uv tool)" command -v ruff
 
+# pnpm + bun (Homebrew formulae)
+check "pnpm installed (Homebrew formula)" command -v pnpm
+check "bun installed (Homebrew formula)" command -v bun
+
+# pnpm + bun global packages
+check "cowsay installed (pnpm global)" test -e "$HOME/Library/pnpm/cowsay"
+check "cowsay installed (bun global)" test -e "$HOME/.bun/bin/cowsay"
+
 # Git config
 check_equal "git user.email configured" \
   "$(git config --global user.email)" "ci-test@example.com"

--- a/tests/ubuntu/vars.yaml
+++ b/tests/ubuntu/vars.yaml
@@ -10,6 +10,8 @@ apt_packages:
   - name: git
   - name: git-lfs
   - name: jq
+  - name: nodejs
+  - name: npm
 
 snap_packages: []
 
@@ -19,7 +21,13 @@ pipx_packages:
 
 uv_tools:
 
-npm_global_packages: []
+npm_global_packages:
+  - bun
+  - pnpm
+
+pnpm_global_packages:
+
+bun_global_packages:
 
 dotnet_tools: []
 

--- a/tests/ubuntu/verify.sh
+++ b/tests/ubuntu/verify.sh
@@ -37,6 +37,10 @@ check "git installed (APT package)" command -v git
 check "git-lfs installed (APT package)" command -v git-lfs
 check "jq installed (APT package)" command -v jq
 
+# pnpm + bun (installed via npm into ~/.local/bin)
+check "bun installed (npm global)" test -x "$HOME/.local/bin/bun"
+check "pnpm installed (npm global)" test -x "$HOME/.local/bin/pnpm"
+
 # Git config
 check_equal "git user.email configured" \
   "$(git config --global user.email)" "ci-test@example.com"

--- a/tests/windows/vars.yaml
+++ b/tests/windows/vars.yaml
@@ -1,7 +1,9 @@
 choco_packages:
+  - name: bun
   - name: git
     parameters: /WindowsTerminal /NoShellIntegration
   - name: jq
+  - name: pnpm
 
 powershell_modules:
   - Pester
@@ -13,6 +15,10 @@ pipx_packages:
 uv_tools:
 
 npm_global_packages: []
+
+pnpm_global_packages:
+
+bun_global_packages:
 
 dotnet_tools: []
 

--- a/tests/windows/verify.ps1
+++ b/tests/windows/verify.ps1
@@ -38,6 +38,8 @@ function Test-Equal {
 # Chocolatey packages
 Test-Check "jq installed (Chocolatey package)" { Get-Command jq -ErrorAction Stop }
 Test-Check "git installed (Chocolatey package)" { Get-Command git -ErrorAction Stop }
+Test-Check "bun installed (Chocolatey package)" { Get-Command bun -ErrorAction Stop }
+Test-Check "pnpm installed (Chocolatey package)" { Get-Command pnpm -ErrorAction Stop }
 
 # PowerShell module
 Test-Check "Pester installed (PowerShell module)" {

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -12,7 +12,7 @@ development environment.
 - 🔧 **PowerShell Setup**: Installs PowerShell and modules for development
 - 🐍 **Python Setup**: Installs Python versions via pyenv, bootstraps uv via pipx, and installs CLI tools via uv
 - 💎 **Ruby Setup**: Installs Ruby via rbenv
-- 🟦 **Node.js Setup**: Installs Node.js and npm global packages
+- 🟦 **Node.js Setup**: Installs Node.js and npm/pnpm/bun global packages
 - 🦀 **Rust Setup**: Installs Rust via rustup
 - ⚡ **Go Setup**: Installs Go
 - 🔷 **.NET Setup**: Installs .NET SDK and global tools

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -229,6 +229,97 @@
         - npm
         - packages
 
+    # pnpm presence check
+    - name: Check if pnpm is installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which pnpm
+      register: pnpm_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - pnpm
+        - packages
+
+    # pnpm global package checks
+    - name: Check if pnpm packages are already installed
+      ansible.builtin.shell: |
+        export PNPM_HOME=~/.local/share/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        pnpm list -g {{ item }}
+      register: pnpm_check_result
+      changed_when: false
+      failed_when: false
+      when: pnpm_check.rc == 0
+      loop: "{{ pnpm_global_packages | default([], true) }}"
+      loop_control:
+        label: "Checking pnpm package: {{ item }}"
+      tags:
+        - pnpm
+        - packages
+
+    # pnpm global package installs
+    - name: Ensure pnpm global packages are installed
+      ansible.builtin.shell: |
+        export PNPM_HOME=~/.local/share/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        mkdir -p "$PNPM_HOME"
+        pnpm add -g {{ item.0 }}
+      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+      when:
+        - pnpm_check.rc == 0
+        - item.1.rc is defined
+        - item.1.rc != 0
+      register: pnpm_install_result
+      changed_when: "pnpm_install_result.rc == 0"
+      loop_control:
+        label: "Installing pnpm package: {{ item.0 }}"
+      tags:
+        - pnpm
+        - packages
+
+    # bun presence check
+    - name: Check if bun is installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which bun
+      register: bun_check
+      changed_when: false
+      failed_when: false
+      tags:
+        - bun
+        - packages
+
+    # bun global package list
+    - name: Check if bun packages are already installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:~/.bun/bin:$PATH
+        bun pm ls -g
+      register: bun_list_result
+      changed_when: false
+      failed_when: false
+      when: bun_check.rc == 0
+      tags:
+        - bun
+        - packages
+
+    # bun global package installs
+    - name: Ensure bun global packages are installed
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:~/.bun/bin:$PATH
+        bun add -g {{ item }}
+      loop: "{{ bun_global_packages | default([], true) }}"
+      when:
+        - bun_check.rc == 0
+        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+      register: bun_install_result
+      changed_when: "bun_install_result.rc == 0"
+      loop_control:
+        label: "Installing bun package: {{ item }}"
+      tags:
+        - bun
+        - packages
+
     # .NET Install check
     - name: Check if dotnet is installed
       ansible.builtin.command:

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -246,8 +246,8 @@
     # output (keyed by bare name) rather than the exit code.
     - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/.local/share/pnpm
-        export PATH=~/.local/bin:$PNPM_HOME:$PATH
+        export PNPM_HOME=~/Library/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         pnpm list -g --depth=0 --json
       register: pnpm_list_result
       changed_when: false
@@ -258,12 +258,15 @@
         - packages
 
     # pnpm global package installs
+    # pnpm installs global binaries into its global bin dir ($PNPM_HOME/bin,
+    # pnpm's default), which must exist and be on PATH or it errors with
+    # ERR_PNPM_NO_GLOBAL_BIN_DIR. This mirrors the PNPM_HOME + $PNPM_HOME/bin
+    # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/.local/share/pnpm
-        export PATH=~/.local/bin:$PNPM_HOME:$PATH
-        mkdir -p "$PNPM_HOME"
-        pnpm config set global-bin-dir "$PNPM_HOME"
+        export PNPM_HOME=~/Library/pnpm
+        export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
+        mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -263,6 +263,7 @@
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
         mkdir -p "$PNPM_HOME"
+        pnpm config set global-bin-dir "$PNPM_HOME"
         pnpm add -g {{ item }}
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -311,7 +311,7 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item | regex_replace('@[^/]*$', '') not in (bun_list_result.stdout | default(''))
+        - item not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       loop_control:

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -246,7 +246,7 @@
     # output (keyed by bare name) rather than the exit code.
     - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/Library/pnpm
+        export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         pnpm list -g --depth=0 --json
       register: pnpm_list_result
@@ -264,7 +264,7 @@
     # convention in the shell configs, so no pnpm config file is written.
     - name: Ensure pnpm global packages are installed
       ansible.builtin.shell: |
-        export PNPM_HOME=~/Library/pnpm
+        export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME/bin:$PATH
         mkdir -p "$PNPM_HOME/bin"
         pnpm add -g {{ item }}

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -241,19 +241,18 @@
         - pnpm
         - packages
 
-    # pnpm global package checks
-    - name: Check if pnpm packages are already installed
+    # pnpm global package list
+    # pnpm list -g always exits 0, so detect installed packages from the JSON
+    # output (keyed by bare name) rather than the exit code.
+    - name: Check which pnpm global packages are already installed
       ansible.builtin.shell: |
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
-        pnpm list -g {{ item }}
-      register: pnpm_check_result
+        pnpm list -g --depth=0 --json
+      register: pnpm_list_result
       changed_when: false
       failed_when: false
       when: pnpm_check.rc == 0
-      loop: "{{ pnpm_global_packages | default([], true) }}"
-      loop_control:
-        label: "Checking pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages
@@ -264,16 +263,15 @@
         export PNPM_HOME=~/.local/share/pnpm
         export PATH=~/.local/bin:$PNPM_HOME:$PATH
         mkdir -p "$PNPM_HOME"
-        pnpm add -g {{ item.0 }}
-      loop: "{{ pnpm_global_packages | default([], true) | zip(pnpm_check_result.results | default([], true)) | list }}"
+        pnpm add -g {{ item }}
+      loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item.1.rc is defined
-        - item.1.rc != 0
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
-        label: "Installing pnpm package: {{ item.0 }}"
+        label: "Installing pnpm package: {{ item }}"
       tags:
         - pnpm
         - packages

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -306,13 +306,23 @@ uv_tools:
   - taskcat
 
 # npm global packages
+# pnpm and bun are installed here via npm so they are available for the
+# pnpm_global_packages / bun_global_packages steps and easy to update.
 npm_global_packages:
   - '@github/copilot'
   - '@vue/cli'
   - aws-cdk
   - azure-functions-core-tools@4
+  - bun
   - npmrc
+  - pnpm
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:

--- a/windows/README.md
+++ b/windows/README.md
@@ -171,6 +171,26 @@ npm_global_packages:
   # etc.
 ```
 
+### pnpm Global Packages
+
+Packages installed globally with pnpm (installed only if `pnpm` is present):
+
+```yaml
+pnpm_global_packages:
+  - aws-cdk
+  # etc.
+```
+
+### bun Global Packages
+
+Packages installed globally with bun (installed only if `bun` is present):
+
+```yaml
+bun_global_packages:
+  - aws-cdk
+  # etc.
+```
+
 ### .NET Global Tools
 
 .NET global tools to install (requires .NET SDK):

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -732,9 +732,12 @@ if ($null -eq $pnpmCmd) {
     # Test
     Write-Verbose -Message '[Test] pnpm global packages from Vars file import...'
     if ($pnpmGlobalPackages -and $pnpmGlobalPackages.Count -gt 0) {
-        # Get the list of currently installed pnpm global packages
+        # Get the list of currently installed pnpm global packages.
+        # pnpm list -g --json returns an array of global store objects; collect
+        # the installed dependency names (keyed by bare name, without @version).
         Write-Verbose -Message '[Get] Currently installed pnpm global packages...'
-        $pnpmGlobalPackagesInstalled = pnpm list -g --depth=0 --json | ConvertFrom-Json
+        $pnpmInstalledNames = @(pnpm list -g --depth=0 --json | ConvertFrom-Json) |
+            ForEach-Object -Process { $_.dependencies.PSObject.Properties.Name }
         foreach ($package in $pnpmGlobalPackages) {
             Write-Progress -Activity $activity -Status (
                 & $StatusBlock
@@ -743,7 +746,9 @@ if ($null -eq $pnpmCmd) {
 
             # Get
             Write-Verbose -Message "[Get] pnpm global package: $package"
-            $pnpmPackageInstalled = $pnpmGlobalPackagesInstalled.dependencies.$package
+            # A version-pinned spec (name@version) won't exact-match a bare name,
+            # so it is (re)installed to honor the pin; unpinned names are skipped.
+            $pnpmPackageInstalled = $pnpmInstalledNames -contains $package
 
             # Test
             Write-Verbose -Message "[Test] pnpm global package: $package"

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -724,6 +724,9 @@ if ($null -eq $pnpmCmd) {
     if (($env:PATH -split ';') -notcontains $env:PNPM_HOME) {
         $env:PATH = "$env:PNPM_HOME;$env:PATH"
     }
+    # Pin global-bin-dir to PNPM_HOME so `pnpm add -g` does not error with
+    # ERR_PNPM_NO_GLOBAL_BIN_DIR and binaries land in a known location.
+    pnpm config set global-bin-dir $env:PNPM_HOME | Out-Null
 
     # Get
     Write-Verbose -Message '[Get] pnpm global packages from Vars file import...'

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -697,6 +697,138 @@ if ($npmGlobalPackages -and $npmGlobalPackages.Count -gt 0) {
 
 #endregion Ensure npm global Packages from Vars file are Installed
 
+#region Ensure pnpm global Packages from Vars file are Installed
+
+$step++
+$stepText = 'Ensure pnpm global Packages from Vars file are Installed'
+Write-Progress -Activity $activity -Status (& $statusBlock) -PercentComplete ($step / $totalSteps * 100)
+Write-Information -MessageData 'Checking for pnpm global packages to install...'
+
+# Get
+Write-Verbose -Message '[Get] pnpm...'
+$pnpmCmd = Get-Command -Name pnpm -ErrorAction SilentlyContinue
+
+# Test
+Write-Verbose -Message '[Test] pnpm...'
+if ($null -eq $pnpmCmd) {
+    Write-Information -MessageData 'pnpm is not installed, skipping pnpm global package installations.'
+} else {
+    # pnpm requires a configured global bin directory (PNPM_HOME) for `pnpm add -g`.
+    Write-Verbose -Message '[Set] Ensuring PNPM_HOME is configured...'
+    if (-not $env:PNPM_HOME) {
+        $env:PNPM_HOME = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'pnpm'
+    }
+    if (-not (Test-Path -Path $env:PNPM_HOME)) {
+        New-Item -Path $env:PNPM_HOME -ItemType Directory -Force | Out-Null
+    }
+    if (($env:PATH -split ';') -notcontains $env:PNPM_HOME) {
+        $env:PATH = "$env:PNPM_HOME;$env:PATH"
+    }
+
+    # Get
+    Write-Verbose -Message '[Get] pnpm global packages from Vars file import...'
+    $pnpmGlobalPackages = $vars.pnpm_global_packages
+
+    # Test
+    Write-Verbose -Message '[Test] pnpm global packages from Vars file import...'
+    if ($pnpmGlobalPackages -and $pnpmGlobalPackages.Count -gt 0) {
+        # Get the list of currently installed pnpm global packages
+        Write-Verbose -Message '[Get] Currently installed pnpm global packages...'
+        $pnpmGlobalPackagesInstalled = pnpm list -g --depth=0 --json | ConvertFrom-Json
+        foreach ($package in $pnpmGlobalPackages) {
+            Write-Progress -Activity $activity -Status (
+                & $StatusBlock
+            ) -CurrentOperation $package -PercentComplete ($step / $totalSteps * 100)
+            Write-Information -MessageData "Checking for pnpm global package $package..."
+
+            # Get
+            Write-Verbose -Message "[Get] pnpm global package: $package"
+            $pnpmPackageInstalled = $pnpmGlobalPackagesInstalled.dependencies.$package
+
+            # Test
+            Write-Verbose -Message "[Test] pnpm global package: $package"
+            if (-not $pnpmPackageInstalled) {
+                # Set
+                Write-Verbose -Message "[Set] pnpm global package $package is not installed, installing..."
+                try {
+                    pnpm add -g $package
+                    Write-Verbose -Message "[Set] pnpm global package $package is now installed."
+                    Write-Information -MessageData "Installed pnpm global package: $package."
+                } catch {
+                    Write-Error -Message "Failed to install pnpm global package: $package. Error: $_"
+                }
+            } else {
+                Write-Information -MessageData "pnpm global package $package is already installed."
+            }
+        }
+    } else {
+        Write-Information -MessageData 'No pnpm global packages specified in vars.yaml file.'
+    }
+}
+
+#endregion Ensure pnpm global Packages from Vars file are Installed
+
+#region Ensure bun global Packages from Vars file are Installed
+
+$step++
+$stepText = 'Ensure bun global Packages from Vars file are Installed'
+Write-Progress -Activity $activity -Status (& $statusBlock) -PercentComplete ($step / $totalSteps * 100)
+Write-Information -MessageData 'Checking for bun global packages to install...'
+
+# Get
+Write-Verbose -Message '[Get] bun...'
+$bunCmd = Get-Command -Name bun -ErrorAction SilentlyContinue
+
+# Test
+Write-Verbose -Message '[Test] bun...'
+if ($null -eq $bunCmd) {
+    Write-Information -MessageData 'bun is not installed, skipping bun global package installations.'
+} else {
+    # Get
+    Write-Verbose -Message '[Get] bun global packages from Vars file import...'
+    $bunGlobalPackages = $vars.bun_global_packages
+
+    # Test
+    Write-Verbose -Message '[Test] bun global packages from Vars file import...'
+    if ($bunGlobalPackages -and $bunGlobalPackages.Count -gt 0) {
+        # Get the list of currently installed bun global packages
+        Write-Verbose -Message '[Get] Currently installed bun global packages...'
+        $bunGlobalPackagesInstalled = bun pm ls -g 2>$null | Out-String
+        foreach ($package in $bunGlobalPackages) {
+            Write-Progress -Activity $activity -Status (
+                & $StatusBlock
+            ) -CurrentOperation $package -PercentComplete ($step / $totalSteps * 100)
+            Write-Information -MessageData "Checking for bun global package $package..."
+
+            # Get
+            Write-Verbose -Message "[Get] bun global package: $package"
+            # Strip a trailing @version (but keep a leading scope like @scope/name)
+            $packageName = $package -replace '(?<!^)@[^/]*$', ''
+            $bunPackageInstalled = $bunGlobalPackagesInstalled -match [regex]::Escape($packageName)
+
+            # Test
+            Write-Verbose -Message "[Test] bun global package: $package"
+            if (-not $bunPackageInstalled) {
+                # Set
+                Write-Verbose -Message "[Set] bun global package $package is not installed, installing..."
+                try {
+                    bun add -g $package
+                    Write-Verbose -Message "[Set] bun global package $package is now installed."
+                    Write-Information -MessageData "Installed bun global package: $package."
+                } catch {
+                    Write-Error -Message "Failed to install bun global package: $package. Error: $_"
+                }
+            } else {
+                Write-Information -MessageData "bun global package $package is already installed."
+            }
+        }
+    } else {
+        Write-Information -MessageData 'No bun global packages specified in vars.yaml file.'
+    }
+}
+
+#endregion Ensure bun global Packages from Vars file are Installed
+
 #region Ensure .NET Global Tools from Vars file are Installed
 
 $step++

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -720,12 +720,14 @@ if ($null -eq $pnpmCmd) {
     # ERR_PNPM_NO_GLOBAL_BIN_DIR. This mirrors the PNPM_HOME + $PNPM_HOME\bin
     # convention in the shell profiles, so no pnpm config file is written.
     if (-not $env:PNPM_HOME) {
-        $env:PNPM_HOME = Join-Path -Path $HOME -ChildPath 'Library/pnpm'
+        $env:PNPM_HOME = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'pnpm'
     }
+
     $pnpmBinDir = Join-Path -Path $env:PNPM_HOME -ChildPath 'bin'
     if (-not (Test-Path -Path $pnpmBinDir)) {
         New-Item -Path $pnpmBinDir -ItemType Directory -Force | Out-Null
     }
+
     if (($env:PATH -split ';') -notcontains $pnpmBinDir) {
         $env:PATH = "$pnpmBinDir;$env:PATH"
     }

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -802,9 +802,9 @@ if ($null -eq $bunCmd) {
 
             # Get
             Write-Verbose -Message "[Get] bun global package: $package"
-            # Strip a trailing @version (but keep a leading scope like @scope/name)
-            $packageName = $package -replace '(?<!^)@[^/]*$', ''
-            $bunPackageInstalled = $bunGlobalPackagesInstalled -match [regex]::Escape($packageName)
+            # Match the full requested spec (incl. any pinned @version) against the
+            # installed list so re-pinning to a different version triggers a reinstall.
+            $bunPackageInstalled = $bunGlobalPackagesInstalled -match [regex]::Escape($package)
 
             # Test
             Write-Verbose -Message "[Test] bun global package: $package"

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -715,18 +715,20 @@ if ($null -eq $pnpmCmd) {
 } else {
     # pnpm requires a configured global bin directory (PNPM_HOME) for `pnpm add -g`.
     Write-Verbose -Message '[Set] Ensuring PNPM_HOME is configured...'
+    # pnpm installs global binaries into its global bin dir ($PNPM_HOME\bin,
+    # pnpm's default), which must exist and be on PATH or it errors with
+    # ERR_PNPM_NO_GLOBAL_BIN_DIR. This mirrors the PNPM_HOME + $PNPM_HOME\bin
+    # convention in the shell profiles, so no pnpm config file is written.
     if (-not $env:PNPM_HOME) {
-        $env:PNPM_HOME = Join-Path -Path $env:LOCALAPPDATA -ChildPath 'pnpm'
+        $env:PNPM_HOME = Join-Path -Path $HOME -ChildPath 'Library/pnpm'
     }
-    if (-not (Test-Path -Path $env:PNPM_HOME)) {
-        New-Item -Path $env:PNPM_HOME -ItemType Directory -Force | Out-Null
+    $pnpmBinDir = Join-Path -Path $env:PNPM_HOME -ChildPath 'bin'
+    if (-not (Test-Path -Path $pnpmBinDir)) {
+        New-Item -Path $pnpmBinDir -ItemType Directory -Force | Out-Null
     }
-    if (($env:PATH -split ';') -notcontains $env:PNPM_HOME) {
-        $env:PATH = "$env:PNPM_HOME;$env:PATH"
+    if (($env:PATH -split ';') -notcontains $pnpmBinDir) {
+        $env:PATH = "$pnpmBinDir;$env:PATH"
     }
-    # Pin global-bin-dir to PNPM_HOME so `pnpm add -g` does not error with
-    # ERR_PNPM_NO_GLOBAL_BIN_DIR and binaries land in a known location.
-    pnpm config set global-bin-dir $env:PNPM_HOME | Out-Null
 
     # Get
     Write-Verbose -Message '[Get] pnpm global packages from Vars file import...'

--- a/windows/vars.yaml
+++ b/windows/vars.yaml
@@ -12,6 +12,7 @@ choco_packages:
   - name: azure-cli
   - name: azure-functions-core-tools
   - name: bicep
+  - name: bun
   - name: citrix-workspace
   - name: cursoride
   - name: docker
@@ -43,6 +44,7 @@ choco_packages:
   - name: nvm
   - name: office365business
   - name: packer
+  - name: pnpm
   # Required to for pipx_packages
   - name: python
   - name: pwsh
@@ -122,6 +124,12 @@ npm_global_packages:
   - aws-cdk
   - npmrc
   - serverless
+
+# pnpm global packages (installed only if pnpm is present)
+pnpm_global_packages:
+
+# bun global packages (installed only if bun is present)
+bun_global_packages:
 
 # .NET Global Tools
 dotnet_tools:


### PR DESCRIPTION
## Summary

Adds two parallel config lists — `pnpm_global_packages` and `bun_global_packages` —
across all five platforms (macOS, Windows, Ubuntu, Debian, Fedora), so global CLI
tools can be installed via pnpm or bun the same way they already are via npm.

Like `uv_tools`, the install steps are **guarded on the binary being present** and
skip silently otherwise. The binaries are installed declaratively as ordinary
package-manager entries:

- **macOS** — Homebrew `pnpm` and `bun` formulae (both now in homebrew-core, bottled)
- **Windows** — Chocolatey `pnpm` and `bun`
- **Linux** — installed via `npm_global_packages` (`pnpm`, `bun`), reusing the
  existing Node/npm toolchain so they stay easy to update

pnpm requires a global bin directory, so the steps set `PNPM_HOME`
(`~/Library/pnpm` on macOS, `~/.local/share/pnpm` on Linux, `%LOCALAPPDATA%\pnpm`
on Windows) and add it to `PATH`.

`examples/macOS_vars.yaml` migrates its `npm_global_packages` into
`bun_global_packages` (bun is now the default), leaving npm empty.

## Notable correctness details

- **bun version pins** — the already-installed check matches the full requested
  spec against `bun pm ls -g` output (which prints `name@version`), so re-pinning
  to a different version triggers a reinstall while unversioned packages stay
  idempotent.
- **pnpm detection** — `pnpm list -g` exits `0` whether or not a package is present
  (unlike `npm ls`, which exits `1` when absent). Detection parses
  `pnpm list -g --json` (keyed by bare name) instead of the exit code, so pnpm
  globals actually install. Bare-name keys also mean a pinned `name@version`
  reinstalls to honor the pin.

## Tests

- **macOS** fixture exercises the full path: installs `bun` + `pnpm` via Homebrew
  and a global `cowsay` through each, verified in `verify.sh`.
- **Linux** fixtures add Node + npm so bun/pnpm install via npm; verify they land
  in `~/.local/bin`.
- **Windows** fixture verifies the choco binaries via `Get-Command`.

## Validation

yamllint, shellcheck, `ansible-playbook --syntax-check`, ansible-lint (production
profile, all four playbooks), PSScriptAnalyzer (no new findings), and
markdownlint-cli2 all pass. No setup scripts were run locally — integration
verification happens in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)