### PR TITLE
chore(ci): run Python lint tools via cached uvx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,10 @@ jobs:
       fedora: ${{ steps.filter.outputs.fedora }}
       debian: ${{ steps.filter.outputs.debian }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -72,14 +74,16 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install validation tools
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         id: setup-uv
         with:
           enable-cache: true
@@ -131,7 +135,9 @@ jobs:
     if: needs.detect-changes.outputs.macos == 'true'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Copy test fixtures
         run: cp tests/macOS/vars.yaml macOS/vars.yaml
@@ -152,7 +158,9 @@ jobs:
     if: needs.detect-changes.outputs.ubuntu == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Copy test fixtures
         run: cp tests/ubuntu/vars.yaml ubuntu/vars.yaml
@@ -174,7 +182,9 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:43
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install container prerequisites
         run: dnf install -y sudo findutils
@@ -199,7 +209,9 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install container prerequisites
         run: apt-get update && apt-get install -y sudo findutils
@@ -223,7 +235,9 @@ jobs:
     if: needs.detect-changes.outputs.windows == 'true'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Copy test fixtures
         run: Copy-Item tests/windows/vars.yaml windows/vars.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,11 @@ name: Test
 permissions:
   contents: read
 
+env:
+  # Pins uv's view of PyPI and keys the uv cache in the validate job.
+  # Bump this date to pick up newer tool releases and invalidate the cache.
+  UV_EXCLUDE_NEWER: "2026-07-14"
+
 on:
   push:
     branches: [main]
@@ -73,13 +78,24 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
-          pip install yamllint ansible-lint
+
+      - uses: astral-sh/setup-uv@v8
+        id: setup-uv
+        with:
+          enable-cache: true
+          cache-dependency-glob: ""
+          cache-suffix: tools-${{ env.UV_EXCLUDE_NEWER }}
+          prune-cache: false
+
+      - name: Use cache-only uv on cache hits
+        if: steps.setup-uv.outputs.cache-hit == 'true'
+        run: echo "UV_OFFLINE=1" >> "$GITHUB_ENV"
 
       - name: YAML lint
-        run: yamllint macOS/vars.yaml ubuntu/vars.yaml windows/vars.yaml fedora/vars.yaml debian/vars.yaml
+        run: uvx yamllint macOS/vars.yaml ubuntu/vars.yaml windows/vars.yaml fedora/vars.yaml debian/vars.yaml
 
       - name: YAML lint (test fixtures)
-        run: yamllint tests/macOS/vars.yaml tests/ubuntu/vars.yaml tests/windows/vars.yaml tests/fedora/vars.yaml tests/debian/vars.yaml
+        run: uvx yamllint tests/macOS/vars.yaml tests/ubuntu/vars.yaml tests/windows/vars.yaml tests/fedora/vars.yaml tests/debian/vars.yaml
 
       - name: shellcheck
         run: |
@@ -94,21 +110,21 @@ jobs:
           pwsh -Command "Invoke-ScriptAnalyzer -Path windows/setup.ps1 -Recurse -ReportSummary"
 
       - name: Install Ansible collections
-        run: ansible-galaxy collection install community.general
+        run: uvx --from ansible-core ansible-galaxy collection install community.general
 
       - name: ansible-lint
         run: |
-          ansible-lint macOS/setup.yaml
-          ansible-lint ubuntu/setup.yaml
-          ansible-lint fedora/setup.yaml
-          ansible-lint debian/setup.yaml
+          uvx ansible-lint macOS/setup.yaml
+          uvx ansible-lint ubuntu/setup.yaml
+          uvx ansible-lint fedora/setup.yaml
+          uvx ansible-lint debian/setup.yaml
 
       - name: Ansible syntax check
         run: |
-          ansible-playbook --syntax-check macOS/setup.yaml
-          ansible-playbook --syntax-check ubuntu/setup.yaml
-          ansible-playbook --syntax-check fedora/setup.yaml
-          ansible-playbook --syntax-check debian/setup.yaml
+          uvx --from ansible-core ansible-playbook --syntax-check macOS/setup.yaml
+          uvx --from ansible-core ansible-playbook --syntax-check ubuntu/setup.yaml
+          uvx --from ansible-core ansible-playbook --syntax-check fedora/setup.yaml
+          uvx --from ansible-core ansible-playbook --syntax-check debian/setup.yaml
 
   integration-macos:
     needs: [detect-changes, validate]


### PR DESCRIPTION
## Summary

- Replace bare `pip install yamllint ansible-lint` in the validate job with `uvx` invocations backed by `setup-uv`'s cache, keyed on a workflow-level `UV_EXCLUDE_NEWER` date.
- Tool versions are now reproducible (uv ignores PyPI releases newer than the pinned date); bumping the date upgrades all tools and invalidates the cache in one place.
- On cache hits, `UV_OFFLINE=1` is set so the job makes zero PyPI requests.
- `ansible-galaxy` / `ansible-playbook` (previously provided transitively by the pip install) now run via `uvx --from ansible-core`.
- Security hardening, mirroring ryanspletzer.github.io: all actions pinned to full commit SHAs with version comments, `persist-credentials: false` on all checkouts, and a weekly grouped dependabot config for github-actions to keep the pins fresh.

Cache pattern from [Simon Willison's TIL](https://til.simonwillison.net/github-actions/uvx-github-actions-cache).

## Test plan

- `actionlint` and `yamllint` pass locally on the edited/new files.
- CI on this PR exercises the validate job end-to-end (first run populates the cache; a re-run hits it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)