### PR TITLE
ci: run Test workflow on all pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,10 @@ on:
       - ".github/workflows/**"
       - ".yamllint.yaml"
       - ".ansible-lint"
+  # No paths filter on pull_request: required status checks deadlock as
+  # "Expected" when the workflow never triggers, so validate must run on
+  # every PR. Integration jobs still skip via detect-changes.
   pull_request:
-    paths:
-      - "macOS/**"
-      - "ubuntu/**"
-      - "windows/**"
-      - "fedora/**"
-      - "debian/**"
-      - "tests/**"
-      - ".github/workflows/**"
-      - ".yamllint.yaml"
-      - ".ansible-lint"
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Summary

- Remove the `paths:` filter from the `pull_request` trigger (the `push` trigger keeps its filter).
- Rationale: the new `protect-main` ruleset requires status checks from this workflow; with a paths filter, a docs-only PR never triggers the workflow and the required checks deadlock as "Expected". Now `validate` (~1 min) runs on every PR, and the integration jobs still skip for unrelated changes via `detect-changes` (skipped jobs satisfy required checks).

## Test plan

- `actionlint` passes locally.
- CI on this PR runs the full workflow (it touches `.github/workflows/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)