### PR TITLE
fix: resolve cross-platform bugs found in repo audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,26 +93,31 @@ Package lists are flat YAML arrays grouped by category:
 
 ```bash
 # macOS
-chmod 700 ./macOS/setup.sh
-./macOS/setup.sh -e your.email@example.com
+cd macOS
+chmod 700 ./setup.sh
+./setup.sh -e your.email@example.com
 
 # Ubuntu
-chmod 700 ./ubuntu/setup.sh
-./ubuntu/setup.sh -e your.email@example.com
+cd ubuntu
+chmod 700 ./setup.sh
+./setup.sh -e your.email@example.com
 
 # Debian
-chmod 700 ./debian/setup.sh
-./debian/setup.sh -e your.email@example.com
+cd debian
+chmod 700 ./setup.sh
+./setup.sh -e your.email@example.com
 
 # Fedora
-chmod 700 ./fedora/setup.sh
-./fedora/setup.sh -e your.email@example.com
+cd fedora
+chmod 700 ./setup.sh
+./setup.sh -e your.email@example.com
 ```
 
 ```powershell
 # Windows (run as Administrator)
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
-.\windows\setup.ps1 -e your.email@example.com
+cd windows
+.\setup.ps1 -e your.email@example.com
 ```
 
 Common flags: `-v` (verbose, repeatable), `-e` (git email),

--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -169,13 +169,17 @@ EOF
 
 echo "Configured Ansible logging to: $LOG_FILE" | tee -a "$LOG_FILE"
 
-# Build extra vars for Git email and name if provided
+# Build extra vars as JSON so values with spaces or quotes survive parsing
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 EXTRA_VARS=""
 if [ -n "$GIT_EMAIL" ]; then
-  EXTRA_VARS="$EXTRA_VARS git_user_email='$GIT_EMAIL'"
+  EXTRA_VARS="\"git_user_email\": \"$(json_escape "$GIT_EMAIL")\""
 fi
 if [ -n "$GIT_NAME" ]; then
-  EXTRA_VARS="$EXTRA_VARS git_user_name='$GIT_NAME'"
+  EXTRA_VARS="${EXTRA_VARS:+$EXTRA_VARS, }\"git_user_name\": \"$(json_escape "$GIT_NAME")\""
 fi
 
 # Run the playbook with the specified verbosity
@@ -185,7 +189,7 @@ if [ -n "$VERBOSITY" ]; then
 fi
 
 if [ -n "$EXTRA_VARS" ]; then
-  ansible-playbook $VERBOSITY --extra-vars "$EXTRA_VARS" "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
   ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
 fi

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -272,7 +272,7 @@
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies', default={}) | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
@@ -314,7 +314,8 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item not in (bun_list_result.stdout | default(''))
+        # bun pm ls -g prints "── <name>@<version>"; anchor with space+@ to avoid substring false matches
+        - (' ' ~ item ~ '@') not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       loop_control:
@@ -356,7 +357,7 @@
       failed_when: false
       when:
         - dotnet_check.rc == 0
-        - item not in dotnet_tools_list.stdout
+        - (item | lower) not in (dotnet_tools_list.stdout | default('') | lower)
       loop_control:
         label: "Installing .NET tool: {{ item }}"
       tags:
@@ -419,8 +420,9 @@
 
     # uv tool setup
     - name: Check if uv is installed
-      ansible.builtin.command:
-        cmd: which uv
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which uv
       register: uv_check
       changed_when: false
       failed_when: false
@@ -429,8 +431,9 @@
         - tools
 
     - name: Install uv tools
-      ansible.builtin.command:
-        cmd: uv tool install {{ item }}
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        uv tool install {{ item }}
       when: uv_check.rc == 0
       loop: "{{ uv_tools | default([], true) }}"
       failed_when: false
@@ -449,6 +452,7 @@
       loop: "{{ vscode_extensions | default([], true) }}"
       register: vscode_ext_result
       changed_when: "'already installed' not in vscode_ext_result.stdout"
+      failed_when: false
       loop_control:
         label: "Installing VS Code extension: {{ item }}"
       tags:

--- a/debian/vars.yaml
+++ b/debian/vars.yaml
@@ -15,6 +15,9 @@ appimage_packages:
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
+    # The download URL is x64-only, so skip on other architectures
+    supported_architectures:
+      - amd64
     # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
     # checksum: "sha256:abc123..."
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
@@ -459,7 +462,7 @@ custom_commands_user:
 custom_commands_elevated:
   # Add commands to execute with elevated privileges
   # Add Docker User
-  - command: usermod -aG docker $USER
+  - command: usermod -aG docker {{ ansible_user_id }}
     description: Add current user to Docker group
 
 # Custom script path (optional)

--- a/fedora/setup.sh
+++ b/fedora/setup.sh
@@ -169,13 +169,17 @@ EOF
 
 echo "Configured Ansible logging to: $LOG_FILE" | tee -a "$LOG_FILE"
 
-# Build extra vars for Git email and name if provided
+# Build extra vars as JSON so values with spaces or quotes survive parsing
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 EXTRA_VARS=""
 if [ -n "$GIT_EMAIL" ]; then
-  EXTRA_VARS="$EXTRA_VARS git_user_email='$GIT_EMAIL'"
+  EXTRA_VARS="\"git_user_email\": \"$(json_escape "$GIT_EMAIL")\""
 fi
 if [ -n "$GIT_NAME" ]; then
-  EXTRA_VARS="$EXTRA_VARS git_user_name='$GIT_NAME'"
+  EXTRA_VARS="${EXTRA_VARS:+$EXTRA_VARS, }\"git_user_name\": \"$(json_escape "$GIT_NAME")\""
 fi
 
 # Run the playbook with the specified verbosity
@@ -185,7 +189,7 @@ if [ -n "$VERBOSITY" ]; then
 fi
 
 if [ -n "$EXTRA_VARS" ]; then
-  ansible-playbook $VERBOSITY --extra-vars "$EXTRA_VARS" "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
   ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
 fi

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -262,7 +262,7 @@
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies', default={}) | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
@@ -304,7 +304,8 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item not in (bun_list_result.stdout | default(''))
+        # bun pm ls -g prints "── <name>@<version>"; anchor with space+@ to avoid substring false matches
+        - (' ' ~ item ~ '@') not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       loop_control:
@@ -346,7 +347,7 @@
       failed_when: false
       when:
         - dotnet_check.rc == 0
-        - item not in dotnet_tools_list.stdout
+        - (item | lower) not in (dotnet_tools_list.stdout | default('') | lower)
       loop_control:
         label: "Installing .NET tool: {{ item }}"
       tags:
@@ -409,8 +410,9 @@
 
     # uv tool setup
     - name: Check if uv is installed
-      ansible.builtin.command:
-        cmd: which uv
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which uv
       register: uv_check
       changed_when: false
       failed_when: false
@@ -419,8 +421,9 @@
         - tools
 
     - name: Install uv tools
-      ansible.builtin.command:
-        cmd: uv tool install {{ item }}
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        uv tool install {{ item }}
       when: uv_check.rc == 0
       loop: "{{ uv_tools | default([], true) }}"
       failed_when: false
@@ -439,6 +442,7 @@
       loop: "{{ vscode_extensions | default([], true) }}"
       register: vscode_ext_result
       changed_when: "'already installed' not in vscode_ext_result.stdout"
+      failed_when: false
       loop_control:
         label: "Installing VS Code extension: {{ item }}"
       tags:

--- a/fedora/vars.yaml
+++ b/fedora/vars.yaml
@@ -15,6 +15,9 @@ appimage_packages:
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
+    # The download URL is x64-only, so skip on other architectures
+    supported_architectures:
+      - x86_64
     # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
     # checksum: "sha256:abc123..."
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
@@ -386,7 +389,7 @@ custom_commands_user:
 custom_commands_elevated:
   # Add commands to execute with elevated privileges
   # Add Docker User
-  - command: usermod -aG docker $USER
+  - command: usermod -aG docker {{ ansible_user_id }}
     description: Add current user to Docker group
 
 # Custom script path (optional)

--- a/macOS/setup.sh
+++ b/macOS/setup.sh
@@ -230,20 +230,24 @@ if [ -z "$GIT_EMAIL" ]; then
   fi
 fi
 
-# Build extra vars for Git email and name if provided
+# Build extra vars as JSON so values with spaces or quotes survive parsing
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 EXTRA_VARS=""
 if [ -n "$GIT_EMAIL" ]; then
   echo "Using provided Git email: $GIT_EMAIL" | tee -a "$LOG_FILE"
-  EXTRA_VARS="$EXTRA_VARS git_user_email='$GIT_EMAIL'"
+  EXTRA_VARS="\"git_user_email\": \"$(json_escape "$GIT_EMAIL")\""
 fi
 if [ -n "$GIT_NAME" ]; then
   echo "Using provided Git name: $GIT_NAME" | tee -a "$LOG_FILE"
-  EXTRA_VARS="$EXTRA_VARS git_user_name='$GIT_NAME'"
+  EXTRA_VARS="${EXTRA_VARS:+$EXTRA_VARS, }\"git_user_name\": \"$(json_escape "$GIT_NAME")\""
 fi
 
 if [ -n "$EXTRA_VARS" ]; then
   /opt/homebrew/bin/ansible-playbook $VERBOSITY \
-    --extra-vars "$EXTRA_VARS" "$PLAYBOOK_FILE"
+    --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
   /opt/homebrew/bin/ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
 fi

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -110,11 +110,6 @@
         - homebrew
         - formulae
 
-    # Refresh Ansible inventory
-    # This ensures that the inventory is up-to-date after Homebrew installations which add to the PATH
-    - name: Refresh Ansible inventory
-      ansible.builtin.meta: refresh_inventory
-
     # PowerShell module setup
     - name: Ensure PowerShell modules are installed
       ansible.builtin.command:
@@ -237,7 +232,7 @@
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies', default={}) | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
@@ -277,7 +272,8 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item not in (bun_list_result.stdout | default(''))
+        # bun pm ls -g prints "── <name>@<version>"; anchor with space+@ to avoid substring false matches
+        - (' ' ~ item ~ '@') not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       environment:
@@ -319,7 +315,7 @@
       failed_when: false
       when:
         - dotnet_check.rc == 0
-        - item not in dotnet_tools_list.stdout
+        - (item | lower) not in (dotnet_tools_list.stdout | default('') | lower)
       loop_control:
         label: "Installing .NET tool: {{ item }}"
       tags:

--- a/ubuntu/setup.sh
+++ b/ubuntu/setup.sh
@@ -169,13 +169,17 @@ EOF
 
 echo "Configured Ansible logging to: $LOG_FILE" | tee -a "$LOG_FILE"
 
-# Build extra vars for Git email and name if provided
+# Build extra vars as JSON so values with spaces or quotes survive parsing
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 EXTRA_VARS=""
 if [ -n "$GIT_EMAIL" ]; then
-  EXTRA_VARS="$EXTRA_VARS git_user_email='$GIT_EMAIL'"
+  EXTRA_VARS="\"git_user_email\": \"$(json_escape "$GIT_EMAIL")\""
 fi
 if [ -n "$GIT_NAME" ]; then
-  EXTRA_VARS="$EXTRA_VARS git_user_name='$GIT_NAME'"
+  EXTRA_VARS="${EXTRA_VARS:+$EXTRA_VARS, }\"git_user_name\": \"$(json_escape "$GIT_NAME")\""
 fi
 
 # Run the playbook with the specified verbosity
@@ -185,7 +189,7 @@ if [ -n "$VERBOSITY" ]; then
 fi
 
 if [ -n "$EXTRA_VARS" ]; then
-  ansible-playbook $VERBOSITY --extra-vars "$EXTRA_VARS" "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
   ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
 fi

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -271,7 +271,7 @@
       loop: "{{ pnpm_global_packages | default([], true) }}"
       when:
         - pnpm_check.rc == 0
-        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies') | map('list') | flatten)
+        - item not in (pnpm_list_result.stdout | default('[]', true) | from_json | map(attribute='dependencies', default={}) | map('list') | flatten)
       register: pnpm_install_result
       changed_when: "pnpm_install_result.rc == 0"
       loop_control:
@@ -313,7 +313,8 @@
       loop: "{{ bun_global_packages | default([], true) }}"
       when:
         - bun_check.rc == 0
-        - item not in (bun_list_result.stdout | default(''))
+        # bun pm ls -g prints "── <name>@<version>"; anchor with space+@ to avoid substring false matches
+        - (' ' ~ item ~ '@') not in (bun_list_result.stdout | default(''))
       register: bun_install_result
       changed_when: "bun_install_result.rc == 0"
       loop_control:
@@ -355,7 +356,7 @@
       failed_when: false
       when:
         - dotnet_check.rc == 0
-        - item not in dotnet_tools_list.stdout
+        - (item | lower) not in (dotnet_tools_list.stdout | default('') | lower)
       loop_control:
         label: "Installing .NET tool: {{ item }}"
       tags:
@@ -418,8 +419,9 @@
 
     # uv tool setup
     - name: Check if uv is installed
-      ansible.builtin.command:
-        cmd: which uv
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        which uv
       register: uv_check
       changed_when: false
       failed_when: false
@@ -428,8 +430,9 @@
         - tools
 
     - name: Install uv tools
-      ansible.builtin.command:
-        cmd: uv tool install {{ item }}
+      ansible.builtin.shell: |
+        export PATH=~/.local/bin:$PATH
+        uv tool install {{ item }}
       when: uv_check.rc == 0
       loop: "{{ uv_tools | default([], true) }}"
       failed_when: false
@@ -448,6 +451,7 @@
       loop: "{{ vscode_extensions | default([], true) }}"
       register: vscode_ext_result
       changed_when: "'already installed' not in vscode_ext_result.stdout"
+      failed_when: false
       loop_control:
         label: "Installing VS Code extension: {{ item }}"
       tags:

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -15,6 +15,9 @@ appimage_packages:
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
+    # The download URL is x64-only, so skip on other architectures
+    supported_architectures:
+      - amd64
     # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
     # checksum: "sha256:abc123..."
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
@@ -67,6 +70,8 @@ external_apt_repositories:
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
+    supported_architectures:
+      - arm64
   # Fish shell latest stable releases
   - name: fish-shell
     signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x59FDA1CE1B84B3FAD89366C027557F056DC33CA5
@@ -240,7 +245,11 @@ apt_packages:
   - name: wine
   # FEX emulator for running x86/x64 applications on ARM64
   - name: fex-emu-armv8.4
+    supported_architectures:
+      - arm64
   - name: fex-emu-wine
+    supported_architectures:
+      - arm64
   # wget
   - name: wget
   # Zoom Workplace for Linux
@@ -570,7 +579,7 @@ custom_commands_user:
 custom_commands_elevated:
   # Add commands to execute with elevated privileges
   # Add Docker User
-  - command: usermod -aG docker $USER
+  - command: usermod -aG docker {{ ansible_user_id }}
     description: Add current user to Docker group
   # Connect Azure Storage Explorer to password manager service
   # See:

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -22,7 +22,7 @@ param (
     [ValidateNotNullOrEmpty()]
     [Alias('n')]
     [string]
-    $GitUserName = (Get-LocalUser -Name $env:USERNAME).FullName
+    $GitUserName = $(try { (Get-LocalUser -Name $env:USERNAME -ErrorAction Stop).FullName } catch { '' })
 )
 
 #region Transcript Setup
@@ -62,12 +62,12 @@ $gitPackageInYaml = (
 # | `[^:]+:`     | everything up to (and including) the first colon               | skips the key name                   |
 # | `\s*`        | optional spaces                                                | ignore padding                       |
 # | `(["'']?)`   | **group 1** – an optional `'` or `"`                           | remembers opening quote if present   |
-# | `([^#'"]+?)` | **group 2** – one or more chars that are **not** `#`, `'`, `"` | captures the value itself            |
+# | `([^#'"]*?)` | **group 2** – zero or more chars that are **not** `#`, `'`, `"` | captures the value itself            |
 # | `\1`         | the same quote captured in group 1                             | ensures we close the quote we opened |
 # | `\s*`        | optional spaces                                                | ignore padding                       |
 # | `(?:#.*)?`   | an optional comment starting with `#` to EOL                   | discards right-hand comments         |
 # | `$`          | end of line                                                    | anchor                               |
-$pattern = '^\s*[^:]+:\s*(["'']?)([^#''"]+?)\1\s*(?:#.*)?$'
+$pattern = '^\s*[^:]+:\s*(["'']?)([^#''"]*?)\1\s*(?:#.*)?$'
 
 # If git.config --global user.email is not set, ensure that one was provided or that the vars.yaml file has a
 # git_user_email entry
@@ -76,7 +76,7 @@ if ([string]::IsNullOrWhiteSpace($(try { git config --global user.email } catch 
     [string]::IsNullOrWhiteSpace(
         (
             Get-Content -Path $VarsFilePath -ErrorAction SilentlyContinue |
-                Where-Object -FilterScript { $_ -match 'git_user_email' } |
+                Where-Object -FilterScript { $_ -match '^\s*git_user_email\s*:' } |
                 ForEach-Object -Process { $_ -replace $pattern, '$2' }
         )
     ) -and
@@ -91,7 +91,7 @@ if ([string]::IsNullOrWhiteSpace($(try { git config --global user.email } catch 
 if ([string]::IsNullOrWhiteSpace($GitUserEmail)) {
     $gitUserEmailFromVars = (
         Get-Content -Path $VarsFilePath -ErrorAction SilentlyContinue |
-            Where-Object -FilterScript { $_ -match 'git_user_email' } |
+            Where-Object -FilterScript { $_ -match '^\s*git_user_email\s*:' } |
             ForEach-Object -Process { $_ -replace $pattern, '$2' }
     )
     if (-not [string]::IsNullOrWhiteSpace($gitUserEmailFromVars)) {
@@ -108,7 +108,7 @@ if ([string]::IsNullOrWhiteSpace($(try { git config --global user.name } catch {
     [string]::IsNullOrWhiteSpace(
         (
             Get-Content -Path $VarsFilePath -ErrorAction SilentlyContinue |
-                Where-Object -FilterScript { $_ -match 'git_user_name' } |
+                Where-Object -FilterScript { $_ -match '^\s*git_user_name\s*:' } |
                 ForEach-Object -Process { $_ -replace $pattern, '$2' }
         )
     ) -and
@@ -123,7 +123,7 @@ if ([string]::IsNullOrWhiteSpace($(try { git config --global user.name } catch {
 if ([string]::IsNullOrWhiteSpace($GitUserName)) {
     $gitUserNameFromVars = (
         Get-Content -Path $VarsFilePath -ErrorAction SilentlyContinue |
-            Where-Object -FilterScript { $_ -match 'git_user_name' } |
+            Where-Object -FilterScript { $_ -match '^\s*git_user_name\s*:' } |
             ForEach-Object -Process { $_ -replace $pattern, '$2' }
     )
     if (-not [string]::IsNullOrWhiteSpace($gitUserNameFromVars)) {
@@ -148,7 +148,7 @@ $totalSteps = (
 ).Count
 
 # Single quotes need to be on the outside
-$statusText = '"Step $($step.ToString().PadLeft($totalSteps.Count.ToString().Length)) of $totalSteps | $stepText"'
+$statusText = '"Step $($step.ToString().PadLeft($totalSteps.ToString().Length)) of $totalSteps | $stepText"'
 
 # This script block allows the string above to use the current values of embedded values each time it's run
 $statusBlock = [ScriptBlock]::Create($statusText)
@@ -419,9 +419,15 @@ $nuGetPackageProvider = powershell -Command {
     Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue
 }
 
+# Get-PackageProvider -ListAvailable can return multiple versions; take the highest.
+$nuGetProviderVersion = $nuGetPackageProvider |
+    ForEach-Object -Process { [version]$_.Version } |
+    Sort-Object -Descending |
+    Select-Object -First 1
+
 # Test
 Write-Verbose -Message '[Test] Windows PowerShell NuGet Package Provider...'
-if (($null -eq $nuGetPackageProvider) -or ($nuGetPackageProvider.Version -lt 2.8.5.201)) {
+if (($null -eq $nuGetProviderVersion) -or ($nuGetProviderVersion -lt [version]'2.8.5.201')) {
     # Set
     Write-Verbose -Message '[Set] Windows PowerShell NuGet Package Provider is not installed, installing...'
     powershell -Command {
@@ -570,6 +576,12 @@ if ($pipxPackages -and $pipxPackages.Count -gt 0) {
     # Get the list of currently installed pipx packages
     Write-Verbose -Message '[Get] Currently installed pipx packages...'
     $pipxPackagesInstalled = pipx list --json | ConvertFrom-Json
+    # pipx list --json returns one object whose venvs property is keyed by package name
+    $pipxInstalledNames = @()
+    if ($pipxPackagesInstalled -and $pipxPackagesInstalled.venvs) {
+        $pipxInstalledNames = @($pipxPackagesInstalled.venvs.PSObject.Properties.Name)
+    }
+
     foreach ($package in $pipxPackages) {
         Write-Progress -Activity $activity -Status (
             & $StatusBlock
@@ -578,11 +590,11 @@ if ($pipxPackages -and $pipxPackages.Count -gt 0) {
 
         # Get
         Write-Verbose -Message "[Get] pipx package: $package"
-        $pipxPackageInstalled = $pipxPackagesInstalled | Where-Object { $_.name -eq $package }
+        $pipxPackageInstalled = $pipxInstalledNames -contains $package
 
         # Test
         Write-Verbose -Message "[Test] pipx package: $package"
-        if ($null -eq $pipxPackageInstalled) {
+        if (-not $pipxPackageInstalled) {
             # Set
             Write-Verbose -Message "[Set] pipx package $package is not installed, installing..."
             try {
@@ -1074,8 +1086,8 @@ if (-not [string]::IsNullOrWhiteSpace($GitUserName) -and
     Write-Verbose -Message "[Set] Git user.name is now set to '$GitUserName'."
     Write-Information -MessageData "Set Git user.name to '$GitUserName'."
 } elseif (-not (Get-Command -Name git -ErrorAction SilentlyContinue)) {
-    Write-Warning -Message 'Git is not installed, cannot set user.email.'
-}  elseif ([string]::IsNullOrWhiteSpace($GitUserName)) {
+    Write-Warning -Message 'Git is not installed, cannot set user.name.'
+} elseif ([string]::IsNullOrWhiteSpace($GitUserName)) {
     Write-Error -Message 'Git user.name is not set and no name was provided.'
 } else {
     Write-Information -MessageData "Git user.name is already set to '$currentGitUserName'."

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -420,8 +420,10 @@ $nuGetPackageProvider = powershell -Command {
 }
 
 # Get-PackageProvider -ListAvailable can return multiple versions; take the highest.
+# The provider comes from a child powershell.exe, so Version is a deserialized
+# property bag — cast via its string form, not the object itself.
 $nuGetProviderVersion = $nuGetPackageProvider |
-    ForEach-Object -Process { [version]$_.Version } |
+    ForEach-Object -Process { [version]"$($_.Version)" } |
     Sort-Object -Descending |
     Select-Object -First 1
 


### PR DESCRIPTION
## Summary

Fixes 16 bugs found in a full audit of the setup scripts, Ansible playbooks, and vars files across all five platforms.

### Windows (`setup.ps1`)
- **Empty-quoted vars extraction**: the value-extraction regex required at least one value char, so `git_user_email: ''` failed to match and `-replace` returned the whole raw line — with the default vars.yaml and no `-e` flag, git user.email got set to the literal string `git_user_email: ''`. The regex now matches empty quoted values, and the line filters are anchored (`^\s*git_user_email\s*:`) so comment lines can't slip in.
- **pipx idempotency**: `pipx list --json` returns `{venvs: {<name>: ...}}`, not an array with `.name`, so the installed-check never matched and every package reinstalled on every run. Now reads `venvs` keys.
- **NuGet provider version check**: the bare literal `2.8.5.201` silently evaluates to `$null` in PowerShell, making the min-version branch dead code. Now compares real `[version]` objects, taking the highest when multiple provider versions are installed.
- **`GitUserName` default**: `Get-LocalUser` throws for domain/Entra ID accounts, aborting the script at parameter binding. Now wrapped in try/catch.
- Step-number padding used `$totalSteps.Count` (always 1); copy-paste "cannot set user.email" message in the user.name branch.

### Ansible playbooks
- **.NET tool check (all platforms)**: `dotnet tool list -g` prints lowercased package IDs, so mixed-case names like `Amazon.Lambda.Tools` never matched and reinstalled (and errored, masked) on every run. Check is now case-insensitive.
- **uv on PATH (Linux)**: uv is installed via pipx into `~/.local/bin`, but the uv tasks used the bare inherited PATH — on a fresh machine every `uv_tools` entry was silently skipped until a re-login and second run. The tasks now export `~/.local/bin` like the neighboring pnpm/bun tasks.
- **VS Code extensions (Linux)**: added `failed_when: false` (parity with macOS) so a missing `code` binary doesn't abort the whole play.
- **pnpm installed-check (all platforms)**: `map(attribute='dependencies')` raises if any `pnpm list -g --json` entry lacks the key (older pnpm omitted it when empty), and a `when:` evaluation error fails the task despite `failed_when: false`. Now uses `default={}`.
- **bun installed-check (all platforms)**: anchored with `" <name>@"` to avoid substring false matches (`foo` vs `foobar`).
- **macOS**: removed the `meta: refresh_inventory` task — it does not refresh `ansible_env`/PATH facts as its comment claimed.

### vars.yaml (Linux)
- **Docker group**: `usermod -aG docker $USER` runs under `become`, where `$USER` is root — the invoking user never got docker access. Now uses `{{ ansible_user_id }}`.
- **FEX (ubuntu)**: the ARM64-only FEX repo and packages had no arch restriction, so the APT install task failed hard on amd64 hosts. Now restricted to `arm64`.
- **Cursor AppImage**: the download URL is x64-only but had no arch restriction, giving ARM64 machines an unrunnable binary. Now restricted to `amd64` (ubuntu/debian) / `x86_64` (fedora).

### setup.sh (all platforms)
- Git email/name are now passed as JSON `--extra-vars` with proper escaping, so names containing apostrophes (O'Brien) or quotes survive parsing.

### Docs
- `AGENTS.md`/`CLAUDE.md` setup instructions now `cd` into each platform directory first — the scripts resolve `vars.yaml`/`setup.yaml` relative to the current directory, so the previously documented repo-root invocation failed.

## Test plan

- [x] Regex, version-comparison, and pipx-shape fixes reproduced and re-verified in pwsh against the fixed code (empty-quoted values, trailing comments, version ordering both directions, empty `venvs`)
- [x] pnpm `when:` expression verified via local Ansible with a `dependencies`-less JSON payload (previously raised, now evaluates)
- [x] JSON `--extra-vars` round-trip verified through Ansible with `Miles O'Brien "Chief"`
- [x] `shellcheck` on all four setup.sh — clean
- [x] `yamllint` on all vars.yaml/setup.yaml — clean
- [x] `ansible-lint` on all four playbooks — 0 failures (production profile)
- [x] `ansible-playbook --syntax-check` on all four playbooks — pass
- [x] `Invoke-ScriptAnalyzer` on setup.ps1 — no new findings vs baseline; file parses clean
- [x] `markdownlint-cli2` on AGENTS.md/CLAUDE.md — 0 errors
- [ ] CI integration jobs (macOS/ubuntu/debian/fedora/windows) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)