### PR TITLE
feat(macOS): re-assert codex-config git clean filter in examples vars

### DIFF
--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -501,6 +501,10 @@ custom_commands_user:
   - git config --global push.default current
   - git config --global push.autoSetupRemote true
   - git config --global user.signingKey 787AEF0BAE232359
+  # Re-assert the codex-config git clean filter used by the home dotfiles repo
+  # (defined in the tracked ~/.gitconfig; strips Codex-written machine state
+  #  from the tracked .codex/config.toml)
+  - git config --global filter.codex-config.clean '~/.agents/bin/codex-config-clean.py'
   # Configure GPG agent to use pinentry-mac (native macOS dialog for YubiKey PIN)
   - echo "Configuring GPG agent to use pinentry-mac..."
   - mkdir -p ~/.gnupg


### PR DESCRIPTION
## Summary

The home dotfiles repo (macos-dotfiles) now commits `.codex/config.toml` through a
`codex-config` git clean filter that strips Codex-written machine state
(absolute-path `[projects]` trust entries, `[hooks.state]` hashes) so the tracked
blob stays portable — see ryanspletzer/macos-dotfiles#21.

The filter is defined in the tracked `~/.gitconfig`, so it activates wherever the
dotfiles are checked out. This adds the same one-liner to `custom_commands_user`
in `examples/macOS_vars.yaml` alongside the other global git configs, following
the existing belt-and-suspenders pattern (gpgsign, push settings, signing key are
likewise both in the tracked `.gitconfig` and re-asserted here).

## Test plan

- [x] Command is idempotent (`git config --global` sets the same value on re-run)
- [x] Filter verified end-to-end in macos-dotfiles (tracked blob contains only
  portable settings; working file keeps machine state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)