### PR TITLE
Fix production package sources surfaced by the first canary run

### DIFF
--- a/debian/vars.yaml
+++ b/debian/vars.yaml
@@ -49,7 +49,9 @@ external_apt_repositories:
   - name: azure-cli
     signed_by: https://packages.microsoft.com/keys/microsoft.asc
     uris: https://packages.microsoft.com/repos/azure-cli
-    suites: "{{ ansible_distribution_release }}"
+    # The azure-cli repo publishes no trixie dist (404); bookworm packages
+    # install fine on Debian 13
+    suites: bookworm
     components: main
     architectures: "{{ deb_architecture }}"
   - name: docker

--- a/examples/debian_vars.yaml
+++ b/examples/debian_vars.yaml
@@ -46,7 +46,9 @@ external_apt_repositories:
   - name: azure-cli
     signed_by: https://packages.microsoft.com/keys/microsoft.asc
     uris: https://packages.microsoft.com/repos/azure-cli
-    suites: "{{ ansible_distribution_release }}"
+    # The azure-cli repo publishes no trixie dist (404); bookworm packages
+    # install fine on Debian 13
+    suites: bookworm
     components: main
     architectures: "{{ deb_architecture }}"
   - name: docker

--- a/examples/ubuntu_vars.yaml
+++ b/examples/ubuntu_vars.yaml
@@ -64,7 +64,7 @@ external_apt_repositories:
     architectures: "{{ deb_architecture }}"
   # .NET SDK 9.0 repository (replaces the dotnet/backports PPA)
   - name: dotnet-backports
-    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0xA4B469963BF863CC"
+    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x45A3F127159BE9E5017811C62125B164E8E5D3FA"
     uris: http://ppa.launchpad.net/dotnet/backports/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
@@ -78,7 +78,7 @@ external_apt_repositories:
     architectures: "{{ deb_architecture }}"
   # Fish shell latest stable releases
   - name: fish-shell
-    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x59FDA1CE1B84B3FAD89366C027557F056DC33CA5
+    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x88421E703EDC7AF54967DED473C9FCC9E2BB48DA
     uris: http://ppa.launchpad.net/fish-shell/release-4/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
@@ -171,14 +171,6 @@ external_apt_repositories:
     suites: stable
     components: main
     architectures: "{{ deb_architecture }}"
-  - name: zoom
-    signed_by: https://zoom.us/linux/download/pubkey
-    uris: https://zoom.us/client/latest
-    suites: "{{ ansible_distribution_release }}"
-    components: main
-    architectures: "{{ deb_architecture }}"
-    supported_architectures:
-      - amd64
   - name: zulu
     signed_by: https://www.azul.com/files/0xB1998361219BD9C9.txt
     uris: https://repos.azul.com/zulu/deb
@@ -290,9 +282,9 @@ apt_packages:
   # Zoom Workplace for Linux
   # amd64 only, arm64 not supported
   - name: yubikey-manager
-  - name: zoom
-    supported_architectures:
-      - amd64
+  # Zoom ships a standalone .deb (https://zoom.us/client/latest is a
+  # download path, not an APT repository), so it cannot be installed here;
+  # install it manually or via a custom command
   # Zulu OpenJDK
   - name: zsh-autosuggestions
   - name: zsh-syntax-highlighting

--- a/fedora/vars.yaml
+++ b/fedora/vars.yaml
@@ -37,7 +37,13 @@ dnf_packages_prereqs:
 
 # External DNF repositories
 # This uses the ansible.builtin.yum_repository module
-external_dnf_repositories: []
+external_dnf_repositories:
+  # Visual Studio Code repository (provides the code package below)
+  - name: vscode
+    description: Visual Studio Code
+    baseurl: https://packages.microsoft.com/yumrepos/vscode
+    gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+    gpgcheck: true
 
 # DNF packages
 dnf_packages:

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -60,7 +60,7 @@ external_apt_repositories:
     architectures: "{{ deb_architecture }}"
   # .NET SDK 9.0 repository (replaces the dotnet/backports PPA)
   - name: dotnet-backports
-    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0xA4B469963BF863CC"
+    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x45A3F127159BE9E5017811C62125B164E8E5D3FA"
     uris: http://ppa.launchpad.net/dotnet/backports/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
@@ -76,7 +76,7 @@ external_apt_repositories:
       - arm64
   # Fish shell latest stable releases
   - name: fish-shell
-    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x59FDA1CE1B84B3FAD89366C027557F056DC33CA5
+    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x88421E703EDC7AF54967DED473C9FCC9E2BB48DA
     uris: http://ppa.launchpad.net/fish-shell/release-4/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
@@ -142,14 +142,6 @@ external_apt_repositories:
     suites: stable
     components: main
     architectures: "{{ deb_architecture }}"
-  - name: zoom
-    signed_by: https://zoom.us/linux/download/pubkey
-    uris: https://zoom.us/client/latest
-    suites: "{{ ansible_distribution_release }}"
-    components: main
-    architectures: "{{ deb_architecture }}"
-    supported_architectures:
-      - amd64
   - name: zulu
     signed_by: https://www.azul.com/files/0xB1998361219BD9C9.txt
     uris: https://repos.azul.com/zulu/deb
@@ -257,9 +249,9 @@ apt_packages:
   # Zoom Workplace for Linux
   # amd64 only, arm64 not supported
   - name: yubikey-manager
-  - name: zoom
-    supported_architectures:
-      - amd64
+  # Zoom ships a standalone .deb (https://zoom.us/client/latest is a
+  # download path, not an APT repository), so it cannot be installed here;
+  # install it manually or via a custom command
   # Zulu OpenJDK
   - name: zsh-autosuggestions
   - name: zsh-syntax-highlighting


### PR DESCRIPTION
## Summary

The first canary run (workflow added in #30) installed the REAL `vars.yaml` on every platform for the first time and found four genuine breakages:

| Platform | Failure | Fix |
| --- | --- | --- |
| fedora | `dnf install code` — "No package code available"; `external_dnf_repositories` was empty | Add the Microsoft vscode yum repo (the fedora example already had it — the real config had drifted behind its own example) |
| ubuntu | `dotnet/backports` and `fish-shell/release-4` PPAs fail signature verification (NO_PUBKEY) | Both PPAs rotated signing keys; `signed_by` now fetches the current fingerprints, verified against the Launchpad API |
| ubuntu | `https://zoom.us/client/latest noble` has no Release file, breaking `apt update` | Remove the entry — that URL is a .deb download path, not an APT repo; zoom can't be installed via APT (noted in a comment) |
| debian | azure-cli repo has no `trixie` dist (404 on InRelease) | Pin `suites: bookworm` (200), whose packages install fine on Debian 13 |

macOS passed with the full production Homebrew list. Windows is still running; any findings there will follow separately.

All repo checks pass locally: yamllint, schema validation, sort order, example key drift.

## Test plan

- [ ] validate job green
- [ ] After merge: `gh workflow run Canary` and confirm canary-fedora / canary-ubuntu / canary-debian pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)