### PR TITLE
Fix cursor URL, ngrok source, and bashrc handling (canary round 2)

### DIFF
--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -384,6 +384,8 @@
         path: ~/.bashrc
         line: 'export PATH="$HOME/.dotnet/tools:$PATH"'
         state: present
+        create: true
+        mode: "0644"
       when: dotnet_check.rc == 0
       tags:
         - dotnet

--- a/debian/vars.yaml
+++ b/debian/vars.yaml
@@ -11,7 +11,9 @@ appimage_install_dir: "{{ ansible_env.HOME }}/.local/bin"
 # AppImage packages
 appimage_packages:
   - name: cursor
-    url: "https://downloader.cursor.sh/linux/appImage/x64"
+    # Cursor publishes only hash-versioned direct URLs; refresh from
+    # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
+    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"

--- a/examples/debian_vars.yaml
+++ b/examples/debian_vars.yaml
@@ -11,7 +11,9 @@ appimage_install_dir: "{{ ansible_env.HOME }}/.local/bin"
 # AppImage packages
 appimage_packages:
   - name: cursor
-    url: "https://downloader.cursor.sh/linux/appImage/x64"
+    # Cursor publishes only hash-versioned direct URLs; refresh from
+    # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
+    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"

--- a/examples/fedora_vars.yaml
+++ b/examples/fedora_vars.yaml
@@ -11,7 +11,9 @@ appimage_install_dir: "{{ ansible_env.HOME }}/.local/bin"
 # AppImage packages
 appimage_packages:
   - name: cursor
-    url: "https://downloader.cursor.sh/linux/appImage/x64"
+    # Cursor publishes only hash-versioned direct URLs; refresh from
+    # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
+    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"

--- a/examples/ubuntu_vars.yaml
+++ b/examples/ubuntu_vars.yaml
@@ -11,7 +11,9 @@ appimage_install_dir: "{{ ansible_env.HOME }}/.local/bin"
 # AppImage packages
 appimage_packages:
   - name: cursor
-    url: "https://downloader.cursor.sh/linux/appImage/x64"
+    # Cursor publishes only hash-versioned direct URLs; refresh from
+    # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
+    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
@@ -116,6 +118,14 @@ external_apt_repositories:
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
+  - name: ngrok
+    signed_by: https://ngrok-agent.s3.amazonaws.com/ngrok.asc
+    uris: https://ngrok-agent.s3.amazonaws.com
+    suites: buster
+    components: main
+    architectures: "{{ deb_architecture }}"
+  # ngrok agent repository (provides the ngrok package below; ngrok uses
+  # the fixed 'buster' suite for all Debian-family releases)
   - name: ngrok
     signed_by: https://ngrok-agent.s3.amazonaws.com/ngrok.asc
     uris: https://ngrok-agent.s3.amazonaws.com

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -362,6 +362,8 @@
         path: ~/.bashrc
         line: 'export PATH="$HOME/.dotnet/tools:$PATH"'
         state: present
+        create: true
+        mode: "0644"
       when: dotnet_check.rc == 0
       tags:
         - dotnet

--- a/fedora/vars.yaml
+++ b/fedora/vars.yaml
@@ -11,7 +11,9 @@ appimage_install_dir: "{{ ansible_env.HOME }}/.local/bin"
 # AppImage packages
 appimage_packages:
   - name: cursor
-    url: "https://downloader.cursor.sh/linux/appImage/x64"
+    # Cursor publishes only hash-versioned direct URLs; refresh from
+    # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
+    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -387,6 +387,8 @@
         path: ~/.bashrc
         line: 'export PATH="$HOME/.dotnet/tools:$PATH"'
         state: present
+        create: true
+        mode: "0644"
       when: dotnet_check.rc == 0
       tags:
         - dotnet

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -11,7 +11,9 @@ appimage_install_dir: "{{ ansible_env.HOME }}/.local/bin"
 # AppImage packages
 appimage_packages:
   - name: cursor
-    url: "https://downloader.cursor.sh/linux/appImage/x64"
+    # Cursor publishes only hash-versioned direct URLs; refresh from
+    # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
+    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
@@ -112,6 +114,14 @@ external_apt_repositories:
     signed_by: https://packages.microsoft.com/keys/microsoft.asc
     uris: "https://packages.microsoft.com/repos/microsoft-ubuntu-{{ ansible_distribution_release }}-prod"
     suites: "{{ ansible_distribution_release }}"
+    components: main
+    architectures: "{{ deb_architecture }}"
+  # ngrok agent repository (provides the ngrok package below; ngrok uses
+  # the fixed 'buster' suite for all Debian-family releases)
+  - name: ngrok
+    signed_by: https://ngrok-agent.s3.amazonaws.com/ngrok.asc
+    uris: https://ngrok-agent.s3.amazonaws.com
+    suites: buster
     components: main
     architectures: "{{ deb_architecture }}"
   # NodeSource repository for Node.js LTS


### PR DESCRIPTION
## Summary

Round 2 of canary-surfaced production fixes (round 1 was #31; that layer now passes and these were hiding behind it):

| Platform | Failure | Fix |
| --- | --- | --- |
| debian/fedora/ubuntu | Cursor AppImage download fails — `downloader.cursor.sh` no longer resolves | Pin the current hash-versioned URL from Cursor's download API (no stable direct URL exists anymore); comment documents how to refresh |
| ubuntu | `No package matching 'ngrok' is available` — package listed, repo never added | Add ngrok's official APT repo (fixed `buster` suite by design) |
| fedora (also latent on debian) | `Destination /github/home/.bashrc does not exist` (rc 257) on the dotnet-tools PATH task | `create: true` on the lineinfile — a genuinely fresh account may have no `.bashrc` |

All local checks pass: yamllint, schemas, sort order, example drift, ansible-lint.

## Test plan

- [ ] validate + integration jobs green
- [ ] After merge: `gh workflow run Canary` — canary-ubuntu/debian/fedora should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)