### PR TITLE
Add the Steam repository for steam-launcher (canary round 3)

### DIFF
--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -131,6 +131,15 @@ external_apt_repositories:
     suites: nodistro
     components: main
     architectures: "{{ deb_architecture }}"
+  # Steam repository (provides the steam-launcher package below)
+  - name: steam
+    signed_by: https://repo.steampowered.com/steam/archive/stable/steam.gpg
+    uris: https://repo.steampowered.com/steam
+    suites: stable
+    components: steam
+    architectures: "{{ deb_architecture }}"
+    supported_architectures:
+      - amd64
   - name: virtualbox
     signed_by: https://www.virtualbox.org/download/oracle_vbox_2016.asc
     uris: https://download.virtualbox.org/virtualbox/debian


### PR DESCRIPTION
## Summary

Canary run 3 result: debian, fedora, and macOS now pass with production vars. Ubuntu had one layer left: `steam-launcher` is listed in `apt_packages` with no repository providing it. The example already carried the correct Steam repo entry — the real vars.yaml had drifted behind its own example (third instance of this pattern). Copied it over.

Also audited for further gaps so this is the last such round-trip: every remaining real package maps to a present repo, and the example-only repos (1password, speedtest, tailscale) have no corresponding packages in the real list.

Windows canary diagnosis is pending: both completed Windows runs failed with the runner dying mid-install (step conclusion null, no logs retained); run 3's Windows job is still running and its logs will be captured on completion.

## Test plan

- [ ] validate + ubuntu integration jobs green
- [ ] After merge: canary-ubuntu passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)