### PR TITLE
Free runner disk space before the Windows canary setup

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -88,9 +88,36 @@ jobs:
         with:
           persist-credentials: false
 
+      # The production choco list needs more free space than the runner
+      # image ships with (~14 GB): three canary runs died with the runner
+      # agent itself crashing on a full C: drive. Delete the largest
+      # preinstalled toolchains this job never uses.
+      - name: Free disk space
+        shell: pwsh
+        run: |
+          Get-PSDrive -Name C | Format-Table -Property Used, Free -AutoSize
+          $targets = @(
+            'C:\Android'                          # Android SDK, ~12 GB
+            'C:\hostedtoolcache\windows\CodeQL'   # CodeQL bundle, ~5 GB
+            'C:\selenium'
+            'C:\SeleniumWebDrivers'
+          )
+          foreach ($target in $targets) {
+            if (Test-Path $target) {
+              Write-Host "Removing $target"
+              Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue
+            }
+          }
+          Get-PSDrive -Name C | Format-Table -Property Used, Free -AutoSize
+
       # Windows PowerShell 5.1 — same rationale as the integration job:
       # a fresh Windows 11 machine bootstraps from stock 5.1.
       - name: Run setup with production vars.yaml
         working-directory: windows
         shell: powershell
         run: .\setup.ps1 -e ci-test@example.com -n "CI Test User"
+
+      - name: Report disk space after setup
+        if: always()
+        shell: pwsh
+        run: Get-PSDrive -Name C | Format-Table -Property Used, Free -AutoSize


### PR DESCRIPTION
## Summary

All three Windows canary runs failed identically: the job's setup step ended with a `null` conclusion, no logs were retained, and the check-run annotation shows the runner agent crashing with "There is not enough space on the disk" while writing its own diag log. The production choco list (office365business, SSMS, docker, qemu, ...) exceeds the ~14 GB free on the runner image's C: drive.

Fix: a pre-step deletes the largest preinstalled toolchains this job never uses (Android SDK ~12 GB, CodeQL ~5 GB, Selenium) and logs `Get-PSDrive` before/after, plus an `if: always()` disk report after setup — so if the list outgrows the freed space later, the failure is visible instead of a silent runner crash.

Canary-environment-only change; no product files touched.

## Test plan

- [ ] validate green (workflow lint covers canary.yml)
- [ ] After merge: `gh workflow run Canary` — canary-windows survives to produce logs (pass or actionable failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)