### PR TITLE
Bootstrap Steam from Valve's standalone .deb (canary round 4)

### DIFF
--- a/examples/ubuntu_vars.yaml
+++ b/examples/ubuntu_vars.yaml
@@ -146,14 +146,6 @@ external_apt_repositories:
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
-  - name: steam
-    signed_by: https://repo.steampowered.com/steam/archive/stable/steam.gpg
-    uris: https://repo.steampowered.com/steam
-    suites: stable
-    components: steam
-    architectures: "{{ deb_architecture }}"
-    supported_architectures:
-      - amd64
   - name: tailscale
     signed_by: "https://pkgs.tailscale.com/stable/ubuntu/{{ ansible_distribution_release }}.noarmor.gpg"
     uris: https://pkgs.tailscale.com/stable/ubuntu
@@ -268,10 +260,6 @@ apt_packages:
   - name: virt-manager
   # Ookla Speedtest CLI - correct package name
   - name: speedtest-cli
-  # amd64 only, arm64 not supported
-  - name: steam-launcher
-    supported_architectures:
-      - amd64
   - name: tailscale
   - name: terraform
   - name: vault
@@ -626,6 +614,17 @@ custom_commands_user:
 # These commands will be executed with elevated privileges (sudo)
 custom_commands_elevated:
   # Add commands to execute with elevated privileges
+  # Steam self-manages its APT source: the steam-launcher package writes
+  # its own sources file and keyring, which conflicts with a pre-added
+  # repo entry (apt refuses duplicate sources with differing Signed-By).
+  # Bootstrap from Valve's standalone .deb instead; amd64 only.
+  - command: >-
+      if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+      curl -fsSL -o /tmp/steam_latest.deb
+      https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
+      && apt-get install -y /tmp/steam_latest.deb; fi
+    description: Install Steam from Valve's standalone .deb (amd64 only)
+    creates: /usr/bin/steam
   # Add Docker User
   - command: usermod -aG docker $USER
     description: Add current user to Docker group

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -131,15 +131,6 @@ external_apt_repositories:
     suites: nodistro
     components: main
     architectures: "{{ deb_architecture }}"
-  # Steam repository (provides the steam-launcher package below)
-  - name: steam
-    signed_by: https://repo.steampowered.com/steam/archive/stable/steam.gpg
-    uris: https://repo.steampowered.com/steam
-    suites: stable
-    components: steam
-    architectures: "{{ deb_architecture }}"
-    supported_architectures:
-      - amd64
   - name: virtualbox
     signed_by: https://www.virtualbox.org/download/oracle_vbox_2016.asc
     uris: https://download.virtualbox.org/virtualbox/debian
@@ -241,10 +232,7 @@ apt_packages:
   - name: qemu-utils
   - name: snapd
   - name: virt-manager
-  # amd64 only, arm64 not supported
-  - name: steam-launcher
-    supported_architectures:
-      - amd64
+  # HashiCorp tools
   - name: terraform
   - name: vault
   # Oracle VirtualBox
@@ -591,6 +579,17 @@ custom_commands_user:
 # These commands will be executed with elevated privileges (sudo)
 custom_commands_elevated:
   # Add commands to execute with elevated privileges
+  # Steam self-manages its APT source: the steam-launcher package writes
+  # its own sources file and keyring, which conflicts with a pre-added
+  # repo entry (apt refuses duplicate sources with differing Signed-By).
+  # Bootstrap from Valve's standalone .deb instead; amd64 only.
+  - command: >-
+      if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+      curl -fsSL -o /tmp/steam_latest.deb
+      https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
+      && apt-get install -y /tmp/steam_latest.deb; fi
+    description: Install Steam from Valve's standalone .deb (amd64 only)
+    creates: /usr/bin/steam
   # Add Docker User
   - command: usermod -aG docker {{ ansible_user_id }}
     description: Add current user to Docker group


### PR DESCRIPTION
## Summary

Canary run 4: debian, fedora, macOS all pass with production vars. Ubuntu surfaced an interaction bug in the round-3 fix: `steam-launcher` installed fine from the added repo, but the package writes its own APT source for the same repo with a different `Signed-By` keyring path, and apt refuses conflicting duplicate sources — every subsequent apt operation failed.

Steam self-manages its APT source by design (the package ships its own sources file and keyring). So this drops the repo entry and the `apt_packages` entry, and instead bootstraps via an elevated custom command installing Valve's stable `steam_latest.deb` (verified live), guarded with `creates: /usr/bin/steam` so reruns skip it. The example carried the same latent conflict and gets the same treatment.

## Test plan

- [ ] validate + ubuntu integration green (ARM may stay red on the ongoing ports.ubuntu.com mirror degradation — environmental)
- [ ] After merge: canary-ubuntu passes end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)