### PR TITLE
Guard sudo custom command; exclude runner-hostile packages from Windows canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -110,6 +110,28 @@ jobs:
           }
           Get-PSDrive -Name C | Format-Table -Property Used, Free -AutoSize
 
+      # Correctness-driven exclusions, not size-driven: run-4 timing showed
+      # the big packages are cheap (office 4m, SSMS 9.5m); these four cannot
+      # install on a hosted runner or are broken upstream.
+      - name: Exclude packages that cannot install on a hosted runner
+        shell: pwsh
+        run: |
+          $exclude = @(
+            'gnupg'            # installer hangs headless until choco's 45-min timeout
+            'nvm'              # its nvm.install dependency hangs the same way
+            'awssamcli'        # MSI error 1603 on the runner image (pending-reboot class)
+            'windows-app-sdk'  # upstream checksum mismatch as of 2026-07-15; re-include when fixed
+          )
+          $out = New-Object System.Collections.Generic.List[string]
+          $skip = $false
+          foreach ($line in Get-Content windows/vars.yaml) {
+            if ($line -match '^  - name: (\S+)') { $skip = $exclude -contains $Matches[1] }
+            elseif ($line -match '^\S') { $skip = $false }
+            if (-not $skip) { $out.Add($line) }
+          }
+          Set-Content -Path windows/vars.yaml -Value $out
+          Write-Host "Excluded: $($exclude -join ', ')"
+
       # Windows PowerShell 5.1 — same rationale as the integration job:
       # a fresh Windows 11 machine bootstraps from stock 5.1.
       - name: Run setup with production vars.yaml

--- a/examples/windows_vars.yaml
+++ b/examples/windows_vars.yaml
@@ -360,9 +360,10 @@ custom_commands:
   - Write-Output -InputObject "Enabling Dark Mode for System and Apps..."
   - Set-ItemProperty -Path HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize -Name SystemUsesLightTheme -Value 0 -Type Dword -Force
   - Set-ItemProperty -Path HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize -Name AppsUseLightTheme -Value 0
-  # Enable sudo
+  # Enable sudo (built-in on Windows 11 24H2+; skip where absent, e.g.
+  # older builds or Windows Server)
   - Write-Output -InputObject "Enabling sudo..."
-  - sudo config --enable normal
+  - if (Get-Command -Name sudo -ErrorAction SilentlyContinue) { sudo config --enable normal } else { Write-Output -InputObject "sudo not available; skipping." }
   # Restart Explorer to apply the theme changes
   - Write-Output -InputObject  "Restarting Explorer to apply theme changes..."
   - Stop-Process -Name explorer

--- a/windows/vars.yaml
+++ b/windows/vars.yaml
@@ -351,9 +351,10 @@ custom_commands:
   - Write-Output -InputObject "Enabling Dark Mode for System and Apps..."
   - Set-ItemProperty -Path HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize -Name SystemUsesLightTheme -Value 0 -Type Dword -Force
   - Set-ItemProperty -Path HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize -Name AppsUseLightTheme -Value 0
-  # Enable sudo
+  # Enable sudo (built-in on Windows 11 24H2+; skip where absent, e.g.
+  # older builds or Windows Server)
   - Write-Output -InputObject "Enabling sudo..."
-  - sudo config --enable normal
+  - if (Get-Command -Name sudo -ErrorAction SilentlyContinue) { sudo config --enable normal } else { Write-Output -InputObject "sudo not available; skipping." }
   # Restart Explorer to apply the theme changes
   - Write-Output -InputObject  "Restarting Explorer to apply theme changes..."
   - Stop-Process -Name explorer


### PR DESCRIPTION
## Summary

Run 4 was the first Windows canary to complete (the disk-space fix in #34 worked — full logs, clean failure). Per-package timing from the log:

| Package | Wall time | Verdict |
| --- | --- | --- |
| gnupg | 45m 07s | installer hangs headless → choco 45-min timeout → fail |
| nvm (via nvm.install) | 45m 04s | same hang class → dependency failure |
| sql-server-management-studio | 9m 32s | fine |
| office365business | 4m 21s | fine |
| citrix-workspace | 3m 48s | fine |
| everything else (41 pkgs) | ≤ 3m each | fine |

So the heavies we suspected are cheap; two hanging installers consumed 90 of the 130 choco minutes. Real failures were: the two hangs, awssamcli (MSI 1603, runner-image class), windows-app-sdk (upstream checksum mismatch), and the fatal one — the `sudo config --enable normal` custom command on a Server image with no `sudo`.

Changes:
- **Production vars + example**: guard the sudo command with `Get-Command` (also more correct on pre-24H2 Windows)
- **canary.yml**: filter those four packages out of the copied vars before setup, each with a documented reason; exclusions are correctness-driven — office/docker/SSMS stay in since they cost minutes and carry real coverage

Expected canary-windows duration: ~55 min, green.

## Test plan

- [ ] validate + integration-windows + unit-windows green
- [ ] After merge: `gh workflow run Canary` — expecting the first fully green run across all five platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)