### PR TITLE
Security review hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,10 @@ jobs:
         run: npx --yes markdownlint-cli2@0.23.0 "**/*.md"
 
       - name: actionlint
-        run: docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.7 -color
+        # Tag is documentation; the digest is what docker actually pulls.
+        # Refresh both together when bumping (Dependabot cannot see images
+        # inside run steps).
+        run: docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 -color
 
       - name: zizmor
         run: uvx zizmor .github/workflows/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Setup run logs and transcripts (full installer output; may capture
+# tokens or other sensitive values printed by tools during setup)
+setup_*.txt
+second-run.log
+
+# Local-only Claude Code permissions
+.claude/settings.local.json

--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -82,7 +82,6 @@ if [ "$CI_MODE" = true ]; then
     echo "Error: CI mode requires passwordless sudo" | tee -a "$LOG_FILE"
     exit 1
   fi
-  export ANSIBLE_SUDO_PASS=""
 else
   # Prompt for sudo password once and store it securely
   read -rs -p "Enter sudo password: " SUDO_PASSWORD
@@ -92,8 +91,12 @@ else
   ( while true; do sudo -k; echo "$SUDO_PASSWORD" | sudo -S -v >/dev/null 2>&1; sleep 15; done ) &
   SUDO_KEEP_ALIVE_PID=$!
 
-  # Export the sudo password as an environment variable for Ansible
-  export ANSIBLE_SUDO_PASS="$SUDO_PASSWORD"
+  # Write the password to a 0600 temp file for ansible-playbook's
+  # --become-password-file flag, so it never enters the environment
+  # inherited by processes the playbook spawns.
+  BECOME_PASS_FILE=$(mktemp)
+  chmod 600 "$BECOME_PASS_FILE"
+  printf '%s\n' "$SUDO_PASSWORD" > "$BECOME_PASS_FILE"
 fi
 
 # Function to clean up before exit
@@ -103,10 +106,12 @@ cleanup() {
     if [ -n "$SUDO_KEEP_ALIVE_PID" ]; then
       kill "$SUDO_KEEP_ALIVE_PID" >/dev/null 2>&1 || true
     fi
-  fi
 
-  # Unset environment variables
-  unset ANSIBLE_SUDO_PASS
+    # Remove the become password file
+    if [ -n "$BECOME_PASS_FILE" ] && [ -f "$BECOME_PASS_FILE" ]; then
+      rm -f "$BECOME_PASS_FILE"
+    fi
+  fi
 }
 
 # Set up trap to ensure cleanup on exit
@@ -188,10 +193,17 @@ if [ -n "$VERBOSITY" ]; then
   echo "Using verbosity level: $VERBOSITY" | tee -a "$LOG_FILE"
 fi
 
+# Pass the become password via file instead of the environment so child
+# processes spawned by the playbook never inherit it.
+BECOME_ARGS=()
+if [ "$CI_MODE" != true ]; then
+  BECOME_ARGS=(--become-password-file "$BECOME_PASS_FILE")
+fi
+
 if [ -n "$EXTRA_VARS" ]; then
-  ansible-playbook $VERBOSITY --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
-  ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" "$PLAYBOOK_FILE"
 fi
 
 echo "Setup complete." | tee -a "$LOG_FILE"

--- a/debian/setup.yaml
+++ b/debian/setup.yaml
@@ -6,9 +6,7 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  # Define the become password at the play level so it's available to all tasks
   vars:
-    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_SUDO_PASS') }}"
     ansible_connection: local
 
   vars_files:

--- a/debian/vars.yaml
+++ b/debian/vars.yaml
@@ -13,15 +13,15 @@ appimage_packages:
   - name: cursor
     # Cursor publishes only hash-versioned direct URLs; refresh from
     # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
-    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
+    url: "https://downloads.cursor.com/production/fc2563ec93d793fc275eef734405a4fdf8b47b26/linux/x64/Cursor-3.11.25-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
     # The download URL is x64-only, so skip on other architectures
     supported_architectures:
       - amd64
-    # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
-    # checksum: "sha256:abc123..."
+    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh
+    checksum: "sha256:69e3f6e83c34ffdf6e1f0612690c16de8d66dfad1f40143fc01bf7ac31e444b0"
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
     # no_sandbox: true
 

--- a/examples/debian_vars.yaml
+++ b/examples/debian_vars.yaml
@@ -13,12 +13,12 @@ appimage_packages:
   - name: cursor
     # Cursor publishes only hash-versioned direct URLs; refresh from
     # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
-    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
+    url: "https://downloads.cursor.com/production/fc2563ec93d793fc275eef734405a4fdf8b47b26/linux/x64/Cursor-3.11.25-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
-    # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
-    # checksum: "sha256:abc123..."
+    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh
+    checksum: "sha256:69e3f6e83c34ffdf6e1f0612690c16de8d66dfad1f40143fc01bf7ac31e444b0"
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
     # no_sandbox: true
 

--- a/examples/fedora_vars.yaml
+++ b/examples/fedora_vars.yaml
@@ -13,12 +13,12 @@ appimage_packages:
   - name: cursor
     # Cursor publishes only hash-versioned direct URLs; refresh from
     # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
-    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
+    url: "https://downloads.cursor.com/production/fc2563ec93d793fc275eef734405a4fdf8b47b26/linux/x64/Cursor-3.11.25-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
-    # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
-    # checksum: "sha256:abc123..."
+    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh
+    checksum: "sha256:69e3f6e83c34ffdf6e1f0612690c16de8d66dfad1f40143fc01bf7ac31e444b0"
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
     # no_sandbox: true
 

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -145,7 +145,7 @@
     "gitlens.ai.vscode.model": "copilot:claude-sonnet-4",
     "gitlens.remotes": [
         {
-            "domain": "git.autodesk.com",
+            "domain": "{{put-github-enterprise-domain-here}}",
             "type": "GitHub"
         }
     ],
@@ -161,16 +161,18 @@
         }
     ],
     "mssql.connections": [
+        // Omit the password key: let the mssql extension prompt for it and
+        // save it in the OS credential store rather than inlining secrets
+        // in settings.json.
         {
             "database": "{{put-database-name-here}}",
-            "password": "{{put-password-here}}",
             "server": "{{put-server-name-here}}",
             "user": "{{put-username-here}}"
         }
     ],
     "omnisharp.enableRoslynAnalyzers": true,
     "parallels-desktop.brew.path": "/opt/homebrew/bin/brew",
-    "parallels-desktop.extension.path": "/Users/spletzr/.parallels-desktop-vscode",
+    "parallels-desktop.extension.path": "/Users/{{put-username-here}}/.parallels-desktop-vscode",
     "parallels-desktop.git.path": "/opt/homebrew/bin/git",
     "parallels-desktop.hashicorp.packer.path": "/opt/homebrew/bin/packer",
     "parallels-desktop.prlctl.path": "/usr/local/bin/prlctl",

--- a/examples/ubuntu_vars.yaml
+++ b/examples/ubuntu_vars.yaml
@@ -67,28 +67,28 @@ external_apt_repositories:
   # .NET SDK 9.0 repository (replaces the dotnet/backports PPA)
   - name: dotnet-backports
     signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x45A3F127159BE9E5017811C62125B164E8E5D3FA"
-    uris: http://ppa.launchpad.net/dotnet/backports/ubuntu
+    uris: https://ppa.launchpadcontent.net/dotnet/backports/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
   # FEX emulator for ARM64
   - name: fex-emu
     signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0xEDB98BFE8A2310DC9C4A376E76DBFEBEA206F5AC"
-    uris: http://ppa.launchpad.net/fex-emu/fex/ubuntu
+    uris: https://ppa.launchpadcontent.net/fex-emu/fex/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
   # Fish shell latest stable releases
   - name: fish-shell
     signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x88421E703EDC7AF54967DED473C9FCC9E2BB48DA
-    uris: http://ppa.launchpad.net/fish-shell/release-4/ubuntu
+    uris: https://ppa.launchpadcontent.net/fish-shell/release-4/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
   # Git latest stable releases
   - name: git-core
     signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24
-    uris: http://ppa.launchpad.net/git-core/ppa/ubuntu
+    uris: https://ppa.launchpadcontent.net/git-core/ppa/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
@@ -162,7 +162,7 @@ external_apt_repositories:
       - amd64
   - name: yubico
     signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x3653E21064B19D134466702E43D5C49532CBA1A9"
-    uris: http://ppa.launchpad.net/yubico/stable/ubuntu
+    uris: https://ppa.launchpadcontent.net/yubico/stable/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"

--- a/examples/ubuntu_vars.yaml
+++ b/examples/ubuntu_vars.yaml
@@ -13,12 +13,12 @@ appimage_packages:
   - name: cursor
     # Cursor publishes only hash-versioned direct URLs; refresh from
     # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
-    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
+    url: "https://downloads.cursor.com/production/fc2563ec93d793fc275eef734405a4fdf8b47b26/linux/x64/Cursor-3.11.25-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
-    # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
-    # checksum: "sha256:abc123..."
+    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh
+    checksum: "sha256:69e3f6e83c34ffdf6e1f0612690c16de8d66dfad1f40143fc01bf7ac31e444b0"
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
     # no_sandbox: true
 
@@ -161,7 +161,7 @@ external_apt_repositories:
     supported_architectures:
       - amd64
   - name: yubico
-    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x32CBA1A9"
+    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x3653E21064B19D134466702E43D5C49532CBA1A9"
     uris: http://ppa.launchpad.net/yubico/stable/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
@@ -618,11 +618,16 @@ custom_commands_elevated:
   # its own sources file and keyring, which conflicts with a pre-added
   # repo entry (apt refuses duplicate sources with differing Signed-By).
   # Bootstrap from Valve's standalone .deb instead; amd64 only.
+  # Download to a random mktemp path rather than a fixed /tmp name so
+  # another local user cannot pre-create the file this root-run command
+  # writes through.
   - command: >-
       if [ "$(dpkg --print-architecture)" = "amd64" ]; then
-      curl -fsSL -o /tmp/steam_latest.deb
+      deb="$(mktemp --suffix=.deb)"
+      && curl -fsSL -o "$deb"
       https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
-      && apt-get install -y /tmp/steam_latest.deb; fi
+      && apt-get install -y "$deb"
+      && rm -f "$deb"; fi
     description: Install Steam from Valve's standalone .deb (amd64 only)
     creates: /usr/bin/steam
   # Add Docker User

--- a/fedora/setup.sh
+++ b/fedora/setup.sh
@@ -82,7 +82,6 @@ if [ "$CI_MODE" = true ]; then
     echo "Error: CI mode requires passwordless sudo" | tee -a "$LOG_FILE"
     exit 1
   fi
-  export ANSIBLE_SUDO_PASS=""
 else
   # Prompt for sudo password once and store it securely
   read -rs -p "Enter sudo password: " SUDO_PASSWORD
@@ -92,8 +91,12 @@ else
   ( while true; do sudo -k; echo "$SUDO_PASSWORD" | sudo -S -v >/dev/null 2>&1; sleep 15; done ) &
   SUDO_KEEP_ALIVE_PID=$!
 
-  # Export the sudo password as an environment variable for Ansible
-  export ANSIBLE_SUDO_PASS="$SUDO_PASSWORD"
+  # Write the password to a 0600 temp file for ansible-playbook's
+  # --become-password-file flag, so it never enters the environment
+  # inherited by processes the playbook spawns.
+  BECOME_PASS_FILE=$(mktemp)
+  chmod 600 "$BECOME_PASS_FILE"
+  printf '%s\n' "$SUDO_PASSWORD" > "$BECOME_PASS_FILE"
 fi
 
 # Function to clean up before exit
@@ -103,10 +106,12 @@ cleanup() {
     if [ -n "$SUDO_KEEP_ALIVE_PID" ]; then
       kill "$SUDO_KEEP_ALIVE_PID" >/dev/null 2>&1 || true
     fi
-  fi
 
-  # Unset environment variables
-  unset ANSIBLE_SUDO_PASS
+    # Remove the become password file
+    if [ -n "$BECOME_PASS_FILE" ] && [ -f "$BECOME_PASS_FILE" ]; then
+      rm -f "$BECOME_PASS_FILE"
+    fi
+  fi
 }
 
 # Set up trap to ensure cleanup on exit
@@ -188,10 +193,17 @@ if [ -n "$VERBOSITY" ]; then
   echo "Using verbosity level: $VERBOSITY" | tee -a "$LOG_FILE"
 fi
 
+# Pass the become password via file instead of the environment so child
+# processes spawned by the playbook never inherit it.
+BECOME_ARGS=()
+if [ "$CI_MODE" != true ]; then
+  BECOME_ARGS=(--become-password-file "$BECOME_PASS_FILE")
+fi
+
 if [ -n "$EXTRA_VARS" ]; then
-  ansible-playbook $VERBOSITY --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
-  ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" "$PLAYBOOK_FILE"
 fi
 
 echo "Setup complete." | tee -a "$LOG_FILE"

--- a/fedora/setup.yaml
+++ b/fedora/setup.yaml
@@ -6,9 +6,7 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  # Define the become password at the play level so it's available to all tasks
   vars:
-    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_SUDO_PASS') }}"
     ansible_connection: local
 
   vars_files:

--- a/fedora/vars.yaml
+++ b/fedora/vars.yaml
@@ -13,15 +13,15 @@ appimage_packages:
   - name: cursor
     # Cursor publishes only hash-versioned direct URLs; refresh from
     # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
-    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
+    url: "https://downloads.cursor.com/production/fc2563ec93d793fc275eef734405a4fdf8b47b26/linux/x64/Cursor-3.11.25-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
     # The download URL is x64-only, so skip on other architectures
     supported_architectures:
       - x86_64
-    # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
-    # checksum: "sha256:abc123..."
+    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh
+    checksum: "sha256:69e3f6e83c34ffdf6e1f0612690c16de8d66dfad1f40143fc01bf7ac31e444b0"
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
     # no_sandbox: true
 

--- a/macOS/setup.sh
+++ b/macOS/setup.sh
@@ -80,7 +80,6 @@ run_and_log() {
 if [ "$CI_MODE" = true ]; then
   echo "CI mode: using passwordless sudo" | tee -a "$LOG_FILE"
   SUDO_PASSWORD=""
-  export ANSIBLE_SUDO_PASS=""
 else
   # Prompt for sudo password once and store it securely
   read -rs -p "Enter sudo password: " SUDO_PASSWORD
@@ -104,7 +103,6 @@ EOF
 
   # Set SUDO_ASKPASS and other environment variables
   export SUDO_ASKPASS="$ASKPASS_SCRIPT"
-  export ANSIBLE_SUDO_PASS="$SUDO_PASSWORD"
 
   # For Homebrew
   export HOMEBREW_SUDO_ASKPASS="$ASKPASS_SCRIPT"
@@ -120,9 +118,7 @@ fi
 cleanup() {
   echo "Performing cleanup..." | tee -a "$LOG_FILE"
 
-  if [ "$CI_MODE" = true ]; then
-    unset ANSIBLE_SUDO_PASS
-  else
+  if [ "$CI_MODE" != true ]; then
     # Kill the sudo refresh process if it exists
     if [ -n "$SUDO_KEEP_ALIVE_PID" ]; then
       echo "Killing sudo keep alive process (PID: $SUDO_KEEP_ALIVE_PID)" | tee -a "$LOG_FILE"
@@ -131,7 +127,6 @@ cleanup() {
 
     # Unset environment variables
     unset SUDO_ASKPASS
-    unset ANSIBLE_SUDO_PASS
     unset HOMEBREW_SUDO_ASKPASS
 
     # Remove the temporary askpass script
@@ -245,11 +240,20 @@ if [ -n "$GIT_NAME" ]; then
   EXTRA_VARS="${EXTRA_VARS:+$EXTRA_VARS, }\"git_user_name\": \"$(json_escape "$GIT_NAME")\""
 fi
 
+# Pass the become password via file instead of the environment so child
+# processes spawned by the playbook never inherit it. The askpass script
+# is executable, so ansible-playbook runs it and uses its stdout
+# (the password from the keychain) as the become password.
+BECOME_ARGS=()
+if [ "$CI_MODE" != true ]; then
+  BECOME_ARGS=(--become-password-file "$ASKPASS_SCRIPT")
+fi
+
 if [ -n "$EXTRA_VARS" ]; then
-  /opt/homebrew/bin/ansible-playbook $VERBOSITY \
+  /opt/homebrew/bin/ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" \
     --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
-  /opt/homebrew/bin/ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
+  /opt/homebrew/bin/ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" "$PLAYBOOK_FILE"
 fi
 
 echo "Setup complete." | tee -a "$LOG_FILE"

--- a/macOS/setup.sh
+++ b/macOS/setup.sh
@@ -89,9 +89,15 @@ else
   KEYCHAIN_SERVICE="ansible-devmachinesetup-temp"
   KEYCHAIN_ACCOUNT="sudo-password"
 
-  # Store password in keychain (overwrite if exists)
+  # Store password in keychain (overwrite if exists). Feed the command to
+  # security's interactive mode over stdin: passing the password to -w as a
+  # command-line argument would expose it to every local process (via ps)
+  # while the command runs. security -i tokenizes like a shell, so escape
+  # backslashes and double quotes to round-trip the password intact.
   security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" >/dev/null 2>&1 || true
-  security add-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w "$SUDO_PASSWORD"
+  printf 'add-generic-password -s "%s" -a "%s" -w "%s"\n' \
+    "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT" \
+    "$(printf '%s' "$SUDO_PASSWORD" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" | security -i
 
   # Create a temporary askpass script that retrieves the password from keychain
   ASKPASS_SCRIPT=$(mktemp)

--- a/macOS/setup.yaml
+++ b/macOS/setup.yaml
@@ -6,9 +6,7 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  # Define the become password at the play level so it's available to all tasks
   vars:
-    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_SUDO_PASS') }}"
     ansible_connection: local
 
   vars_files:

--- a/scripts/bump-cursor.sh
+++ b/scripts/bump-cursor.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# bump-cursor.sh
+# Refreshes the pinned Cursor AppImage url and sha256 checksum across every
+# vars.yaml that installs Cursor (ubuntu/debian/fedora and their examples).
+#
+# Cursor publishes only hash-versioned direct URLs and no official
+# checksums, so the hash is computed from the download itself
+# (trust-on-first-use): it cannot authenticate the initial download, but
+# it pins the artifact so any later change at the same URL -- CDN
+# tampering or corruption -- fails the Ansible get_url step loudly.
+#
+# Usage: scripts/bump-cursor.sh
+# Run from anywhere; paths resolve relative to the repo root.
+
+set -e
+
+api_url='https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable'
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+set -- \
+  "$repo_root/ubuntu/vars.yaml" \
+  "$repo_root/debian/vars.yaml" \
+  "$repo_root/fedora/vars.yaml" \
+  "$repo_root/examples/ubuntu_vars.yaml" \
+  "$repo_root/examples/debian_vars.yaml" \
+  "$repo_root/examples/fedora_vars.yaml"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl is required" >&2
+  exit 1
+fi
+
+# Extract a top-level string field from the API's single-line JSON response
+json_field() {
+  sed -n "s/.*\"$1\":\"\([^\"]*\)\".*/\1/p"
+}
+
+echo "Querying $api_url"
+response=$(curl -fsSL "$api_url")
+download_url=$(printf '%s' "$response" | json_field downloadUrl)
+version=$(printf '%s' "$response" | json_field version)
+
+if [ -z "$download_url" ] || [ -z "$version" ]; then
+  echo "Error: could not parse downloadUrl/version from API response" >&2
+  exit 1
+fi
+
+echo "Latest stable: $version"
+echo "URL: $download_url"
+
+current_url=$(sed -n 's|^ *url: "\(https://downloads\.cursor\.com[^"]*\)"$|\1|p' "$1")
+if [ "$current_url" = "$download_url" ] && grep -q '^    checksum: "sha256:' "$1"; then
+  echo "Already pinned to the latest stable with a checksum; nothing to do."
+  exit 0
+fi
+
+tmp_file=$(mktemp)
+trap 'rm -f "$tmp_file"' EXIT INT TERM
+echo "Downloading the AppImage once to compute its sha256..."
+curl -fsSL -o "$tmp_file" "$download_url"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  hash=$(sha256sum "$tmp_file" | awk '{print $1}')
+else
+  hash=$(shasum -a 256 "$tmp_file" | awk '{print $1}')
+fi
+echo "sha256: $hash"
+
+for f in "$@"; do
+  sed -i.bak \
+    -e "s|url: \"https://downloads\.cursor\.com/[^\"]*\"|url: \"$download_url\"|" \
+    "$f"
+  if grep -q '^    checksum: "sha256:' "$f"; then
+    # Refresh an existing pin
+    sed -i.bak \
+      -e "s|^    checksum: \"sha256:[0-9a-f]*\"|    checksum: \"sha256:$hash\"|" \
+      "$f"
+  else
+    # First pin: turn the commented placeholder into a real checksum and
+    # replace its lead-in comment
+    sed -i.bak \
+      -e 's|^    # Optional: set to a checksum value (e\.g\. "sha256:abc123\.\.\.") to verify the download$|    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh|' \
+      -e "s|^    # checksum: \"sha256:abc123\.\.\.\"$|    checksum: \"sha256:$hash\"|" \
+      "$f"
+  fi
+  rm -f "$f.bak"
+  echo "Updated: $f"
+done
+
+echo "Done. Review the changes with: git diff"

--- a/ubuntu/setup.sh
+++ b/ubuntu/setup.sh
@@ -82,7 +82,6 @@ if [ "$CI_MODE" = true ]; then
     echo "Error: CI mode requires passwordless sudo" | tee -a "$LOG_FILE"
     exit 1
   fi
-  export ANSIBLE_SUDO_PASS=""
 else
   # Prompt for sudo password once and store it securely
   read -rs -p "Enter sudo password: " SUDO_PASSWORD
@@ -92,8 +91,12 @@ else
   ( while true; do sudo -k; echo "$SUDO_PASSWORD" | sudo -S -v >/dev/null 2>&1; sleep 15; done ) &
   SUDO_KEEP_ALIVE_PID=$!
 
-  # Export the sudo password as an environment variable for Ansible
-  export ANSIBLE_SUDO_PASS="$SUDO_PASSWORD"
+  # Write the password to a 0600 temp file for ansible-playbook's
+  # --become-password-file flag, so it never enters the environment
+  # inherited by processes the playbook spawns.
+  BECOME_PASS_FILE=$(mktemp)
+  chmod 600 "$BECOME_PASS_FILE"
+  printf '%s\n' "$SUDO_PASSWORD" > "$BECOME_PASS_FILE"
 fi
 
 # Function to clean up before exit
@@ -103,10 +106,12 @@ cleanup() {
     if [ -n "$SUDO_KEEP_ALIVE_PID" ]; then
       kill "$SUDO_KEEP_ALIVE_PID" >/dev/null 2>&1 || true
     fi
-  fi
 
-  # Unset environment variables
-  unset ANSIBLE_SUDO_PASS
+    # Remove the become password file
+    if [ -n "$BECOME_PASS_FILE" ] && [ -f "$BECOME_PASS_FILE" ]; then
+      rm -f "$BECOME_PASS_FILE"
+    fi
+  fi
 }
 
 # Set up trap to ensure cleanup on exit
@@ -188,10 +193,17 @@ if [ -n "$VERBOSITY" ]; then
   echo "Using verbosity level: $VERBOSITY" | tee -a "$LOG_FILE"
 fi
 
+# Pass the become password via file instead of the environment so child
+# processes spawned by the playbook never inherit it.
+BECOME_ARGS=()
+if [ "$CI_MODE" != true ]; then
+  BECOME_ARGS=(--become-password-file "$BECOME_PASS_FILE")
+fi
+
 if [ -n "$EXTRA_VARS" ]; then
-  ansible-playbook $VERBOSITY --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" --extra-vars "{$EXTRA_VARS}" "$PLAYBOOK_FILE"
 else
-  ansible-playbook $VERBOSITY "$PLAYBOOK_FILE"
+  ansible-playbook $VERBOSITY "${BECOME_ARGS[@]}" "$PLAYBOOK_FILE"
 fi
 
 echo "Setup complete." | tee -a "$LOG_FILE"

--- a/ubuntu/setup.yaml
+++ b/ubuntu/setup.yaml
@@ -6,9 +6,7 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  # Define the become password at the play level so it's available to all tasks
   vars:
-    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_SUDO_PASS') }}"
     ansible_connection: local
 
   vars_files:

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -13,15 +13,15 @@ appimage_packages:
   - name: cursor
     # Cursor publishes only hash-versioned direct URLs; refresh from
     # https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable
-    url: "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage"
+    url: "https://downloads.cursor.com/production/fc2563ec93d793fc275eef734405a4fdf8b47b26/linux/x64/Cursor-3.11.25-x86_64.AppImage"
     comment: "Cursor AI Code Editor"
     categories: "Development;IDE;"
     mime_types: "text/plain;"
     # The download URL is x64-only, so skip on other architectures
     supported_architectures:
       - amd64
-    # Optional: set to a checksum value (e.g. "sha256:abc123...") to verify the download
-    # checksum: "sha256:abc123..."
+    # sha256 of the pinned AppImage; refresh with url via scripts/bump-cursor.sh
+    checksum: "sha256:69e3f6e83c34ffdf6e1f0612690c16de8d66dfad1f40143fc01bf7ac31e444b0"
     # Set to true to pass --no-sandbox to the AppImage (disables Chromium sandbox)
     # no_sandbox: true
 
@@ -140,7 +140,7 @@ external_apt_repositories:
     supported_architectures:
       - amd64
   - name: yubico
-    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x32CBA1A9"
+    signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x3653E21064B19D134466702E43D5C49532CBA1A9"
     uris: http://ppa.launchpad.net/yubico/stable/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
@@ -583,11 +583,16 @@ custom_commands_elevated:
   # its own sources file and keyring, which conflicts with a pre-added
   # repo entry (apt refuses duplicate sources with differing Signed-By).
   # Bootstrap from Valve's standalone .deb instead; amd64 only.
+  # Download to a random mktemp path rather than a fixed /tmp name so
+  # another local user cannot pre-create the file this root-run command
+  # writes through.
   - command: >-
       if [ "$(dpkg --print-architecture)" = "amd64" ]; then
-      curl -fsSL -o /tmp/steam_latest.deb
+      deb="$(mktemp --suffix=.deb)"
+      && curl -fsSL -o "$deb"
       https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
-      && apt-get install -y /tmp/steam_latest.deb; fi
+      && apt-get install -y "$deb"
+      && rm -f "$deb"; fi
     description: Install Steam from Valve's standalone .deb (amd64 only)
     creates: /usr/bin/steam
   # Add Docker User

--- a/ubuntu/vars.yaml
+++ b/ubuntu/vars.yaml
@@ -63,14 +63,14 @@ external_apt_repositories:
   # .NET SDK 9.0 repository (replaces the dotnet/backports PPA)
   - name: dotnet-backports
     signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x45A3F127159BE9E5017811C62125B164E8E5D3FA"
-    uris: http://ppa.launchpad.net/dotnet/backports/ubuntu
+    uris: https://ppa.launchpadcontent.net/dotnet/backports/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
   # FEX emulator for ARM64
   - name: fex-emu
     signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0xEDB98BFE8A2310DC9C4A376E76DBFEBEA206F5AC"
-    uris: http://ppa.launchpad.net/fex-emu/fex/ubuntu
+    uris: https://ppa.launchpadcontent.net/fex-emu/fex/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
@@ -79,14 +79,14 @@ external_apt_repositories:
   # Fish shell latest stable releases
   - name: fish-shell
     signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x88421E703EDC7AF54967DED473C9FCC9E2BB48DA
-    uris: http://ppa.launchpad.net/fish-shell/release-4/ubuntu
+    uris: https://ppa.launchpadcontent.net/fish-shell/release-4/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
   # Git latest stable releases
   - name: git-core
     signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24
-    uris: http://ppa.launchpad.net/git-core/ppa/ubuntu
+    uris: https://ppa.launchpadcontent.net/git-core/ppa/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"
@@ -141,7 +141,7 @@ external_apt_repositories:
       - amd64
   - name: yubico
     signed_by: "https://keyserver.ubuntu.com/pks/lookup?op=get&options=mr&exact=on&search=0x3653E21064B19D134466702E43D5C49532CBA1A9"
-    uris: http://ppa.launchpad.net/yubico/stable/ubuntu
+    uris: https://ppa.launchpadcontent.net/yubico/stable/ubuntu
     suites: "{{ ansible_distribution_release }}"
     components: main
     architectures: "{{ deb_architecture }}"


### PR DESCRIPTION
## Summary

Fixes from a full-repo security review. No behavior changes for CI runs; the interactive sudo path changes mechanism but not UX.

- **Become password via file, not environment** (`--become-password-file`): `ANSIBLE_SUDO_PASS` was exported into the environment of every process the playbooks spawn (installers, npm postinstall hooks, custom scripts). Linux setup scripts now write the password to a `0600` mktemp file removed by the cleanup trap; macOS reuses the keychain-backed askpass script as an executable password file, so the password stays in the keychain. CI mode passes no password and relies on passwordless sudo, as before.
- **Sudo password out of process argument lists (macOS)**: the keychain write now goes through `security -i` on stdin instead of `-w "$PASSWORD"` in argv (visible via `ps`). Escaping verified to round-trip passwords containing spaces, quotes, backslashes, and `$`.
- **Yubico PPA key by full fingerprint**: fetching by 32-bit short key ID is collidable on keyservers (evil32); now pinned to `3653E21064B19D134466702E43D5C49532CBA1A9` (verified as the Launchpad PPA for Yubico key).
- **Steam bootstrap `.deb` via mktemp**: the root-run download wrote to a fixed, predictable `/tmp/steam_latest.deb` another local user could pre-create; now a random mktemp path, cleaned up after install.
- **Cursor AppImage checksum pinned** and bumped 3.11.19 → 3.11.25. Cursor publishes no official hashes, so the new `scripts/bump-cursor.sh` refreshes url + sha256 together from one download (idempotent; fast no-op when current). The weekly canary re-verifies the pin on every run.
- **PPAs over HTTPS**: the five Launchpad `uris` moved from `http://ppa.launchpad.net` to `https://ppa.launchpadcontent.net` (all verified reachable). Last plaintext-HTTP URLs in the repo.
- **actionlint image digest-pinned** in the validate job — the last remote executable in CI pulled by mutable tag. Tag kept for readability; bump tag + digest together (Dependabot cannot see images inside `run:` steps).
- **`.gitignore`**: setup logs / transcripts (full installer output can contain sensitive values) and `.claude/settings.local.json` are no longer committable.
- **`examples/settings.json` scrubbed**: workplace domain and username replaced with the existing `{{put-x-here}}` placeholder convention; inline mssql password key dropped in favor of the extension's credential-store prompt.

Consciously accepted risks (reviewed, no change): `curl | bash` Homebrew installs, community Chocolatey repo as the Windows trust anchor, TLS 1.2 enforcement on the Chocolatey bootstrap (moot on Windows 11 targets).

## Test plan

- [x] shellcheck, bats, yamllint, ansible-playbook --syntax-check (×4), JSON-schema validation, sort + example-drift checks, zizmor — all green locally
- [x] `security -i` password round-trip verified empirically with special characters
- [x] `scripts/bump-cursor.sh` run for the first pin; rerun verified as a no-op
- [ ] PR CI: full integration matrix runs (ubuntu/macOS/windows/fedora/debian paths all touched) — exercises CI-mode sudo, HTTPS PPAs, and the Cursor checksum end-to-end
- [ ] Note: the interactive (non-CI) sudo path cannot be exercised by CI; first interactive run on a real machine validates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)