### PR TITLE
chore(ci): add fedora and debian ARM integration and canary jobs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -62,8 +62,47 @@ jobs:
           chmod 700 ./setup.sh
           ./setup.sh -c -e ci-test@example.com -n "CI Test User"
 
+  # ARM canaries run the real vars.yaml on aarch64 — the only place that
+  # proves every non-arch-gated package and repo actually exists for
+  # aarch64/arm64 (fixtures on the PR ARM jobs only prove skip mechanics).
+  canary-fedora-arm:
+    runs-on: ubuntu-24.04-arm
+    container: fedora:43
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install container prerequisites
+        run: dnf install -y sudo findutils
+
+      - name: Run setup with production vars.yaml
+        working-directory: fedora
+        run: |
+          chmod 700 ./setup.sh
+          ./setup.sh -c -e ci-test@example.com -n "CI Test User"
+
   canary-debian:
     runs-on: ubuntu-latest
+    container: debian:13
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install container prerequisites
+        run: apt-get update && apt-get install -y sudo findutils
+
+      - name: Run setup with production vars.yaml
+        working-directory: debian
+        run: |
+          chmod 700 ./setup.sh
+          ./setup.sh -c -e ci-test@example.com -n "CI Test User"
+
+  canary-debian-arm:
+    runs-on: ubuntu-24.04-arm
     container: debian:13
     timeout-minutes: 180
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,10 +329,96 @@ jobs:
             *) echo "Playbook reported changes or failures on a second run"; exit 1 ;;
           esac
 
+  # ARM runner exercises Fedora's own architecture mechanism (the
+  # rpm_architecture fact with x86_64/aarch64 values), which is distinct
+  # from the dpkg-based amd64/arm64 path the Ubuntu ARM job covers:
+  # aarch64-excluded packages must be skipped cleanly, not attempted and
+  # failed.
+  integration-fedora-arm:
+    needs: [detect-changes, validate]
+    if: needs.detect-changes.outputs.fedora == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    container: fedora:43
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install container prerequisites
+        run: dnf install -y sudo findutils
+
+      - name: Copy test fixtures
+        run: cp tests/fedora/vars.yaml fedora/vars.yaml
+
+      - name: Run setup
+        working-directory: fedora
+        run: |
+          chmod 700 ./setup.sh
+          ./setup.sh -c -e ci-test@example.com -n "CI Test User"
+
+      - name: Verify installation
+        run: |
+          chmod 700 tests/fedora/verify.sh
+          tests/fedora/verify.sh
+
+      - name: Idempotency check (second run reports zero changes)
+        working-directory: fedora
+        run: |
+          ./setup.sh -c -e ci-test@example.com -n "CI Test User" | tee second-run.log
+          recap="$(grep 'localhost' second-run.log | grep 'ok=' | tail -1)"
+          echo "Recap: $recap"
+          case "$recap" in
+            *changed=0*failed=0*) echo "Playbook is idempotent" ;;
+            *) echo "Playbook reported changes or failures on a second run"; exit 1 ;;
+          esac
+
   integration-debian:
     needs: [detect-changes, validate]
     if: needs.detect-changes.outputs.debian == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container: debian:13
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install container prerequisites
+        run: apt-get update && apt-get install -y sudo findutils
+
+      - name: Copy test fixtures
+        run: cp tests/debian/vars.yaml debian/vars.yaml
+
+      - name: Run setup
+        working-directory: debian
+        run: |
+          chmod 700 ./setup.sh
+          ./setup.sh -c -e ci-test@example.com -n "CI Test User"
+
+      - name: Verify installation
+        run: |
+          chmod 700 tests/debian/verify.sh
+          tests/debian/verify.sh
+
+      - name: Idempotency check (second run reports zero changes)
+        working-directory: debian
+        run: |
+          ./setup.sh -c -e ci-test@example.com -n "CI Test User" | tee second-run.log
+          recap="$(grep 'localhost' second-run.log | grep 'ok=' | tail -1)"
+          echo "Recap: $recap"
+          case "$recap" in
+            *changed=0*failed=0*) echo "Playbook is idempotent" ;;
+            *) echo "Playbook reported changes or failures on a second run"; exit 1 ;;
+          esac
+
+  # ARM runner asserts the arm64 skip logic against Debian's vars: the
+  # mechanism is shared with Ubuntu, but the arch-gated entries (and the
+  # external repos templated on deb_architecture) are Debian's own.
+  integration-debian-arm:
+    needs: [detect-changes, validate]
+    if: needs.detect-changes.outputs.debian == 'true'
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     container: debian:13
     steps:

--- a/tests/debian/verify.sh
+++ b/tests/debian/verify.sh
@@ -30,10 +30,15 @@ check "ruff installed (uv tool)" test -x "$HOME/.local/bin/ruff"
 check "json installed (pnpm global)" test -e "$HOME/.local/share/pnpm/bin/json"
 check "cowsay installed (bun global)" test -e "$HOME/.bun/bin/cowsay"
 
-# AppImage
-check "appimagetool AppImage downloaded" test -x "$HOME/.local/bin/appimagetool.AppImage"
-check "appimagetool CLI symlink created" test -L "$HOME/.local/bin/appimagetool"
-check "appimagetool desktop entry created" test -f "$HOME/.local/share/applications/appimagetool.desktop"
+# AppImage (appimagetool is amd64-only; on other architectures the
+# supported_architectures guard must skip it entirely)
+if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+  check "appimagetool AppImage downloaded" test -x "$HOME/.local/bin/appimagetool.AppImage"
+  check "appimagetool CLI symlink created" test -L "$HOME/.local/bin/appimagetool"
+  check "appimagetool desktop entry created" test -f "$HOME/.local/share/applications/appimagetool.desktop"
+else
+  check "appimagetool skipped on non-amd64" test ! -e "$HOME/.local/bin/appimagetool.AppImage"
+fi
 
 # Custom commands (sentinel files prove they ran)
 check "user custom command ran" test -f "$HOME/.dms-ci-user-command-ran"

--- a/tests/fedora/verify.sh
+++ b/tests/fedora/verify.sh
@@ -30,10 +30,15 @@ check "ruff installed (uv tool)" test -x "$HOME/.local/bin/ruff"
 check "json installed (pnpm global)" test -e "$HOME/.local/share/pnpm/bin/json"
 check "cowsay installed (bun global)" test -e "$HOME/.bun/bin/cowsay"
 
-# AppImage
-check "appimagetool AppImage downloaded" test -x "$HOME/.local/bin/appimagetool.AppImage"
-check "appimagetool CLI symlink created" test -L "$HOME/.local/bin/appimagetool"
-check "appimagetool desktop entry created" test -f "$HOME/.local/share/applications/appimagetool.desktop"
+# AppImage (appimagetool is x86_64-only; on other architectures the
+# supported_architectures guard must skip it entirely)
+if [ "$(uname -m)" = "x86_64" ]; then
+  check "appimagetool AppImage downloaded" test -x "$HOME/.local/bin/appimagetool.AppImage"
+  check "appimagetool CLI symlink created" test -L "$HOME/.local/bin/appimagetool"
+  check "appimagetool desktop entry created" test -f "$HOME/.local/share/applications/appimagetool.desktop"
+else
+  check "appimagetool skipped on non-x86_64" test ! -e "$HOME/.local/bin/appimagetool.AppImage"
+fi
 
 # Custom commands (sentinel files prove they ran)
 check "user custom command ran" test -f "$HOME/.dms-ci-user-command-ran"


### PR DESCRIPTION
## Summary

Fedora and Debian previously ran only as amd64 containers (`fedora:43` / `debian:13` on `ubuntu-latest`), so their aarch64 code paths were never executed in CI. This adds ARM variants on the free `ubuntu-24.04-arm` runner, mirroring the existing `integration-ubuntu-arm` pattern.

- **`integration-fedora-arm`** (test.yml): exercises Fedora's own architecture mechanism — the `rpm_architecture` fact with `x86_64`/`aarch64` values — which is distinct from the dpkg-based `amd64`/`arm64` path the existing Ubuntu ARM job covers. A wrong arch value in a `supported_architectures` list would pass every existing job and fail on real ARM hardware.
- **`integration-debian-arm`** (test.yml): the skip mechanism is shared with Ubuntu, but the arch-gated entries and the `deb_architecture`-templated external repos are Debian's own.
- **`canary-fedora-arm`** / **`canary-debian-arm`** (canary.yml): weekly runs of the real production `vars.yaml` on aarch64 — the only place that proves every non-arch-gated package, external repo, and Flatpak actually exists for aarch64/arm64. The PR-level jobs run fixtures, which only prove skip mechanics.

Both integration jobs are gated by the existing `detect-changes` filters and reuse the same fixture-copy / setup / verify / idempotency steps as their amd64 counterparts.

## Test plan

- [x] `yamllint`, `actionlint`, and `zizmor` pass locally on both workflows
- [ ] `integration-fedora-arm` and `integration-debian-arm` run green on this PR (workflow changes trigger all platform filters)
- [ ] After merge, trigger the Canary workflow via `workflow_dispatch` to validate the ARM canaries without waiting for the Monday schedule; first run may surface production packages needing `supported_architectures` gates — that's the point

🤖 Generated with [Claude Code](https://claude.com/claude-code)