### PR TITLE
feat(macOS): add newly installed packages to vars

### DIFF
--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -76,7 +76,9 @@ homebrew_casks:
 
 homebrew_formulae:
   - actionlint
-  - ansible
+  # Bootstrapped by macOS/setup.sh so Ansible itself can run;
+  # deliberately excluded from package sync
+  # - ansible
   - automake
   - aws-sam-cli
   - awscli

--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -123,8 +123,6 @@ homebrew_formulae:
   - jq
   - kubernetes-cli
   - lazygit
-  - libffi
-  - libyaml
   - lua
   - lua-language-server
   - markdownlint-cli
@@ -139,7 +137,6 @@ homebrew_formulae:
   - node
   - nvm
   - oh-my-posh
-  - openssl@3
   - pandoc
   - pinentry-mac
   - pipx
@@ -148,7 +145,6 @@ homebrew_formulae:
   - pyenv-virtualenv
   - python
   - qemu
-  - readline
   - rip2
   - ripgrep
   - ruby-install
@@ -156,7 +152,6 @@ homebrew_formulae:
   - ruff
   - rust-analyzer
   - rustup
-  - shellcheck
   - stylua
   - taplo
   - tdd-guard
@@ -170,7 +165,6 @@ homebrew_formulae:
   - weasyprint
   - wget2
   - xh
-  - xz
   - yaml-language-server
   - yamllint
   - ykman

--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -11,24 +11,31 @@ homebrew_taps:
   - azure/functions
   - hashicorp/tap
   - microsoft/git
+  - oven-sh/bun
   - teamookla/speedtest
 
 homebrew_casks:
   - 1password
+  - antigravity-cli
   - appcleaner
   - brave-browser
   - chatgpt
   - citrix-workspace
   - claude-code
+  - claude-code@latest
+  - codex
   - comet
   - copilot-cli
   - cursor
+  - cursor-cli
   - docker-desktop
   - dotnet-sdk
   - drawio
   - elgato-camera-hub
+  - emacs-app
   - firefox
   - font-caskaydia-cove-nerd-font
+  - font-symbols-only-nerd-font
   - ghostty
   - git-credential-manager
   - google-chrome
@@ -38,10 +45,12 @@ homebrew_casks:
   - keybase
   - kitty
   - krita
+  - microsoft-auto-update
   - microsoft-azure-storage-explorer
   - microsoft-edge
   - microsoft-office
   - microsoft-teams
+  - neo-network-utility
   - netnewswire
   - netspot
   - ngrok
@@ -59,6 +68,7 @@ homebrew_casks:
   - vlc
   - windows-app
   - wine-stable
+  - zed
   # Doesn't work without Rosetta 2
   # - yubico-yubikey-manager
   - zoom
@@ -66,6 +76,8 @@ homebrew_casks:
 
 homebrew_formulae:
   - actionlint
+  - ansible
+  - automake
   - aws-sam-cli
   - awscli
   - azure-cli
@@ -77,7 +89,9 @@ homebrew_formulae:
   - bash-language-server
   - bat
   - beads
+  - betterleaks
   - bicep
+  - bison
   - bun
   - cfn-lint
   - chruby
@@ -109,6 +123,9 @@ homebrew_formulae:
   - jq
   - kubernetes-cli
   - lazygit
+  - libffi
+  - libyaml
+  - lua
   - lua-language-server
   - markdownlint-cli
   - markdownlint-cli2
@@ -116,11 +133,13 @@ homebrew_formulae:
   - mas
   - maven
   - mcp-inspector
+  - micro
   - mtr
   - neovim
   - node
   - nvm
   - oh-my-posh
+  - openssl@3
   - pandoc
   - pinentry-mac
   - pipx
@@ -129,6 +148,7 @@ homebrew_formulae:
   - pyenv-virtualenv
   - python
   - qemu
+  - readline
   - rip2
   - ripgrep
   - ruby-install
@@ -136,6 +156,8 @@ homebrew_formulae:
   - ruff
   - rust-analyzer
   - rustup
+  - shellcheck
+  - stylua
   - taplo
   - tdd-guard
   - teamookla/speedtest/speedtest
@@ -148,6 +170,7 @@ homebrew_formulae:
   - weasyprint
   - wget2
   - xh
+  - xz
   - yaml-language-server
   - yamllint
   - ykman
@@ -161,20 +184,29 @@ homebrew_formulae:
 powershell_modules:
   - AWS.Tools.Common
   - Az.Accounts
+  - BuildHelpers
+  - Deck
   - ExchangeOnlineManagement
+  - Microsoft.Graph.Applications
   - Microsoft.Graph.Authentication
+  - Microsoft.PowerShell.PSResourceGet
+  - PackageManagement
   - Pester
   - platyPS
   - posh-git
   - powershell-yaml
   - PowerShellBuild
+  - PowerShellGet
   - psake
   - PSGraphQL
   - PSJsonWebToken
+  - PSQR
   - PSReadLine
   - PSScriptAnalyzer
   - PSTcpIp
+  - PwshSpectreConsole
   - Terminal-Icons
+  - TextMate
 
 # pipx modules
 pipx_packages:


### PR DESCRIPTION
Adds locally installed packages missing from `examples/macOS_vars.yaml`,
collected by `sync-dev-machine-packages`.

## homebrew_taps

- `oven-sh/bun`

## homebrew_casks

- `antigravity-cli`
- `claude-code@latest`
- `codex`
- `cursor-cli`
- `emacs-app`
- `font-symbols-only-nerd-font`
- `microsoft-auto-update`
- `neo-network-utility`
- `zed`

## homebrew_formulae

- `automake`
- `betterleaks`
- `bison`
- `lua`
- `micro`
- `stylua`

## powershell_modules

- `BuildHelpers`
- `Deck`
- `Microsoft.Graph.Applications`
- `Microsoft.PowerShell.PSResourceGet`
- `PackageManagement`
- `PowerShellGet`
- `PSQR`
- `PwshSpectreConsole`
- `TextMate`

> Review PowerShell modules for transitive dependencies pulled in by other modules.


> Transitive Homebrew dependencies (libffi, libyaml, openssl@3, readline, xz, and shellcheck via actionlint) were dropped from the initial commit; only explicitly wanted leaf formulae are pinned.


> `ansible` is recorded as a commented-out exclusion instead: `macOS/setup.sh` bootstraps it so Ansible itself can run.
