### PR TITLE
fix(macOS): exclude PowerShell built-in modules from vars

### DIFF
--- a/examples/macOS_vars.yaml
+++ b/examples/macOS_vars.yaml
@@ -185,14 +185,17 @@ powershell_modules:
   - ExchangeOnlineManagement
   - Microsoft.Graph.Applications
   - Microsoft.Graph.Authentication
-  - Microsoft.PowerShell.PSResourceGet
-  - PackageManagement
+  # Ships with PowerShell 7 itself; deliberately excluded from sync
+  # - Microsoft.PowerShell.PSResourceGet
+  # Ships with PowerShell 7 itself; deliberately excluded from sync
+  # - PackageManagement
   - Pester
   - platyPS
   - posh-git
   - powershell-yaml
   - PowerShellBuild
-  - PowerShellGet
+  # Ships with PowerShell 7 itself; deliberately excluded from sync
+  # - PowerShellGet
   - psake
   - PSGraphQL
   - PSJsonWebToken


### PR DESCRIPTION
## Summary

- Converts `PowerShellGet`, `PackageManagement`, and `Microsoft.PowerShell.PSResourceGet` — all shipped inside PowerShell 7 itself — from pinned entries into commented-out sync exclusions with the rationale inline
- Uses the established exclusion convention (same as `# - parallels` and `# - ansible`) rather than a collector-side filter, because install location cannot distinguish built-ins: old `Install-Module` runs leave user-scope copies that `Get-PSResource` reports identically to real installs

## Test plan

- [x] `sync_packages.py --dry-run` against this branch reports everything up to date (exclusions respected, nothing re-proposed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)