### PR TITLE
fix(ci): pin uv version and key the uv cache on it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ env:
   # Pins uv's view of PyPI and keys the uv cache in the validate job.
   # Bump this date to pick up newer tool releases and invalidate the cache.
   UV_EXCLUDE_NEWER: "2026-07-15"
+  # Pins the uv binary itself and keys the cache below; a floating "latest"
+  # uv can change the cache format (as 0.11.30 did), which orphans the
+  # restored cache and hard-fails under UV_OFFLINE=1. Bump with the date.
+  UV_VERSION: "0.11.32"
 
 on:
   # No paths filter on push: validate lints the whole repo (docs, examples,
@@ -79,9 +83,10 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         id: setup-uv
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: ""
-          cache-suffix: tools-${{ env.UV_EXCLUDE_NEWER }}
+          cache-suffix: tools-${{ env.UV_EXCLUDE_NEWER }}-uv${{ env.UV_VERSION }}
           prune-cache: false
 
       - name: Use cache-only uv on cache hits


### PR DESCRIPTION
## Summary

- Pin the uv binary via a new `UV_VERSION` env var (`0.11.32`) instead of
  letting setup-uv fall back to latest
- Include the uv version in the cache suffix
  (`tools-<date>-uv<version>`) so any uv bump starts a fresh cache

## Why

uv 0.11.30 (2026-07-20) changed the cached Simple API metadata format.
With a floating uv, the restored Actions cache becomes unreadable, and since
this workflow forces `UV_OFFLINE=1` on cache hits, every `uvx` run then
hard-fails with "package was not found in the cache". This broke CI in
macos-dotfiles (fixed in ryanspletzer/macos-dotfiles#31); this repo uses the
identical recipe and would fail the same way on its next cache-hit run.

The old `tools-2026-07-15` cache is orphaned by the new key and its stale
entry has been deleted; the first run on this branch repopulates it in the
new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)